### PR TITLE
bakels: refactor ingredient groups support

### DIFF
--- a/tests/test_data/bakels.com.au/bakels_2.json
+++ b/tests/test_data/bakels.com.au/bakels_2.json
@@ -1,0 +1,41 @@
+{
+  "author": "Australian Bakels",
+  "canonical_url": "https://www.bakels.com.au/recipes/plant-based-burger-patty-using-bakels-plant-based-savoury-mix/",
+  "host": "bakels.com.au",
+  "description": "Plant-Based Burger Patty Recipe - Australian Bakels | Sponge Cake Mix",
+  "image": "https://www.bakels.com.au/wp-content/uploads/sites/21/2020/08/Vegan-Burger-Patty-scaled.jpg",
+  "ingredients": [
+    "Bakels Plant-Based Savoury Mix",
+    "Vital Wheat Gluten",
+    "Molasses (optional)",
+    "Vegetable Oil",
+    "Water (ambient)"
+  ],
+  "ingredient_groups": [
+    {
+      "ingredients": [
+        "Bakels Plant-Based Savoury Mix",
+        "Vital Wheat Gluten"
+      ],
+      "purpose": "Group 1"
+    },
+    {
+      "ingredients": [
+        "Molasses (optional)",
+        "Vegetable Oil",
+        "Water (ambient)"
+      ],
+      "purpose": "Group 2"
+    }
+  ],
+  "instructions": "Dry blend Group 1 in mixing bowl.\nAdd Group 2 into mixing bowl.\nBlend together on low speed for 5 minutes. Scrape down in between mixing.\nLet the mix stand for 5-10 minutes for full hydration.",
+  "instructions_list": [
+    "Dry blend Group 1 in mixing bowl.",
+    "Add Group 2 into mixing bowl.",
+    "Blend together on low speed for 5 minutes. Scrape down in between mixing.",
+    "Let the mix stand for 5-10 minutes for full hydration."
+  ],
+  "language": "en",
+  "site_name": "Australian Bakels",
+  "title": "Plant-Based Burger Patty (Using Bakels Plant-Based Savoury Mix)"
+}

--- a/tests/test_data/bakels.com.au/bakels_2.testhtml
+++ b/tests/test_data/bakels.com.au/bakels_2.testhtml
@@ -1,0 +1,3823 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+        <link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="https://www.bakels.com.au/feed/" />
+    	<link rel="shortcut icon" href="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/favicon.ico" />
+        <meta name='robots' content='index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1' />
+<link rel="alternate" hreflang="en" href="https://www.bakels.com.au/recipes/plant-based-burger-patty-using-bakels-plant-based-savoury-mix/" />
+<link rel="alternate" hreflang="x-default" href="https://www.bakels.com.au/recipes/plant-based-burger-patty-using-bakels-plant-based-savoury-mix/" />
+
+<!-- Google Tag Manager for WordPress by gtm4wp.com -->
+<script data-cfasync="false" data-pagespeed-no-defer>
+	var gtm4wp_datalayer_name = "dataLayer";
+	var dataLayer = dataLayer || [];
+</script>
+<!-- End Google Tag Manager for WordPress by gtm4wp.com -->
+	<!-- This site is optimized with the Yoast SEO plugin v22.5 - https://yoast.com/wordpress/plugins/seo/ -->
+	<title>Plant-Based Burger Patty Recipe - Australian Bakels | Sponge Cake Mix</title>
+	<link rel="canonical" href="https://www.bakels.com.au/recipes/plant-based-burger-patty-using-bakels-plant-based-savoury-mix/" />
+	<meta property="og:locale" content="en_US" />
+	<meta property="og:type" content="article" />
+	<meta property="og:title" content="Plant-Based Burger Patty Recipe - Australian Bakels | Sponge Cake Mix" />
+	<meta property="og:url" content="https://www.bakels.com.au/recipes/plant-based-burger-patty-using-bakels-plant-based-savoury-mix/" />
+	<meta property="og:site_name" content="Australian Bakels" />
+	<meta property="article:modified_time" content="2021-05-18T04:20:36+00:00" />
+	<meta property="og:image" content="https://www.bakels.com.au/wp-content/uploads/sites/21/2020/08/Vegan-Burger-Patty-scaled.jpg" />
+	<meta property="og:image:width" content="2560" />
+	<meta property="og:image:height" content="1707" />
+	<meta property="og:image:type" content="image/jpeg" />
+	<meta name="twitter:card" content="summary_large_image" />
+	<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[{"@type":"WebPage","@id":"https://www.bakels.com.au/recipes/plant-based-burger-patty-using-bakels-plant-based-savoury-mix/","url":"https://www.bakels.com.au/recipes/plant-based-burger-patty-using-bakels-plant-based-savoury-mix/","name":"Plant-Based Burger Patty Recipe - Australian Bakels | Sponge Cake Mix","isPartOf":{"@id":"https://www.bakels.com.au/#website"},"primaryImageOfPage":{"@id":"https://www.bakels.com.au/recipes/plant-based-burger-patty-using-bakels-plant-based-savoury-mix/#primaryimage"},"image":{"@id":"https://www.bakels.com.au/recipes/plant-based-burger-patty-using-bakels-plant-based-savoury-mix/#primaryimage"},"thumbnailUrl":"https://www.bakels.com.au/wp-content/uploads/sites/21/2020/08/Vegan-Burger-Patty-scaled.jpg","datePublished":"2020-08-27T23:54:41+00:00","dateModified":"2021-05-18T04:20:36+00:00","breadcrumb":{"@id":"https://www.bakels.com.au/recipes/plant-based-burger-patty-using-bakels-plant-based-savoury-mix/#breadcrumb"},"inLanguage":"en-US","potentialAction":[{"@type":"ReadAction","target":["https://www.bakels.com.au/recipes/plant-based-burger-patty-using-bakels-plant-based-savoury-mix/"]}]},{"@type":"ImageObject","inLanguage":"en-US","@id":"https://www.bakels.com.au/recipes/plant-based-burger-patty-using-bakels-plant-based-savoury-mix/#primaryimage","url":"https://www.bakels.com.au/wp-content/uploads/sites/21/2020/08/Vegan-Burger-Patty-scaled.jpg","contentUrl":"https://www.bakels.com.au/wp-content/uploads/sites/21/2020/08/Vegan-Burger-Patty-scaled.jpg","width":2560,"height":1707,"caption":"Plant-Based Burger Patty"},{"@type":"BreadcrumbList","@id":"https://www.bakels.com.au/recipes/plant-based-burger-patty-using-bakels-plant-based-savoury-mix/#breadcrumb","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.bakels.com.au/"},{"@type":"ListItem","position":2,"name":"Plant-Based Burger Patty (Using Bakels Plant-Based Savoury Mix)"}]},{"@type":"WebSite","@id":"https://www.bakels.com.au/#website","url":"https://www.bakels.com.au/","name":"Australian Bakels","description":"","publisher":{"@id":"https://www.bakels.com.au/#organization"},"potentialAction":[{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https://www.bakels.com.au/?s={search_term_string}"},"query-input":"required name=search_term_string"}],"inLanguage":"en-US"},{"@type":"Organization","@id":"https://www.bakels.com.au/#organization","name":"Australian Bakels","url":"https://www.bakels.com.au/","logo":{"@type":"ImageObject","inLanguage":"en-US","@id":"https://www.bakels.com.au/#/schema/logo/image/","url":"https://www.bakels.com.au/wp-content/uploads/sites/21/2018/11/logo-blue.png","contentUrl":"https://www.bakels.com.au/wp-content/uploads/sites/21/2018/11/logo-blue.png","width":460,"height":88,"caption":"Australian Bakels"},"image":{"@id":"https://www.bakels.com.au/#/schema/logo/image/"}}]}</script>
+	<!-- / Yoast SEO plugin. -->
+
+
+<link rel='dns-prefetch' href='//cc.cdn.civiccomputing.com' />
+<script type="text/javascript">
+/* <![CDATA[ */
+window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/15.0.3\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/15.0.3\/svg\/","svgExt":".svg","source":{"concatemoji":"https:\/\/www.bakels.com.au\/wp-includes\/js\/wp-emoji-release.min.js?ver=6.5.2"}};
+/*! This file is auto-generated */
+!function(i,n){var o,s,e;function c(e){try{var t={supportTests:e,timestamp:(new Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),r=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return t.every(function(e,t){return e===r[t]})}function u(e,t,n){switch(t){case"flag":return n(e,"\ud83c\udff3\ufe0f\u200d\u26a7\ufe0f","\ud83c\udff3\ufe0f\u200b\u26a7\ufe0f")?!1:!n(e,"\ud83c\uddfa\ud83c\uddf3","\ud83c\uddfa\u200b\ud83c\uddf3")&&!n(e,"\ud83c\udff4\udb40\udc67\udb40\udc62\udb40\udc65\udb40\udc6e\udb40\udc67\udb40\udc7f","\ud83c\udff4\u200b\udb40\udc67\u200b\udb40\udc62\u200b\udb40\udc65\u200b\udb40\udc6e\u200b\udb40\udc67\u200b\udb40\udc7f");case"emoji":return!n(e,"\ud83d\udc26\u200d\u2b1b","\ud83d\udc26\u200b\u2b1b")}return!1}function f(e,t,n){var r="undefined"!=typeof WorkerGlobalScope&&self instanceof WorkerGlobalScope?new OffscreenCanvas(300,150):i.createElement("canvas"),a=r.getContext("2d",{willReadFrequently:!0}),o=(a.textBaseline="top",a.font="600 32px Arial",{});return e.forEach(function(e){o[e]=t(a,e,n)}),o}function t(e){var t=i.createElement("script");t.src=e,t.defer=!0,i.head.appendChild(t)}"undefined"!=typeof Promise&&(o="wpEmojiSettingsSupports",s=["flag","emoji"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){i.addEventListener("DOMContentLoaded",e,{once:!0})}),new Promise(function(t){var n=function(){try{var e=JSON.parse(sessionStorage.getItem(o));if("object"==typeof e&&"number"==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&"object"==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if("undefined"!=typeof Worker&&"undefined"!=typeof OffscreenCanvas&&"undefined"!=typeof URL&&URL.createObjectURL&&"undefined"!=typeof Blob)try{var e="postMessage("+f.toString()+"("+[JSON.stringify(s),u.toString(),p.toString()].join(",")+"));",r=new Blob([e],{type:"text/javascript"}),a=new Worker(URL.createObjectURL(r),{name:"wpTestEmojiSupports"});return void(a.onmessage=function(e){c(n=e.data),a.terminate(),t(n)})}catch(e){}c(n=f(s,u,p))}t(n)}).then(function(e){for(var t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],"flag"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);
+/* ]]> */
+</script>
+		
+	<link rel='stylesheet' id='wpmf-bakery-style-css' href='https://www.bakels.com.au/wp-content/plugins/wp-media-folder/assets/css/vc_style.css?ver=5.8.4' type='text/css' media='all' />
+<style id='wp-emoji-styles-inline-css' type='text/css'>
+
+	img.wp-smiley, img.emoji {
+		display: inline !important;
+		border: none !important;
+		box-shadow: none !important;
+		height: 1em !important;
+		width: 1em !important;
+		margin: 0 0.07em !important;
+		vertical-align: -0.1em !important;
+		background: none !important;
+		padding: 0 !important;
+	}
+</style>
+<link rel='stylesheet' id='wp-block-library-css' href='https://www.bakels.com.au/wp-includes/css/dist/block-library/style.min.css?ver=6.5.2' type='text/css' media='all' />
+<style id='classic-theme-styles-inline-css' type='text/css'>
+/*! This file is auto-generated */
+.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}
+</style>
+<style id='global-styles-inline-css' type='text/css'>
+body{--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink: #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange: #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan: #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue: #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple: #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium: 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large: 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40: 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70: 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural: 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0, 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255, 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0, 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap: 0.5em;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-constrained > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-constrained > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > :where(:not(.alignleft):not(.alignright):not(.alignfull)){max-width: var(--wp--style--global--content-size);margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > .alignwide{max-width: var(--wp--style--global--wide-size);}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}body .is-layout-flex > *{margin: 0;}body .is-layout-grid{display: grid;}body .is-layout-grid > *{margin: 0;}:where(.wp-block-columns.is-layout-flex){gap: 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap: 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color: var(--wp--preset--color--white) !important;}.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}
+.wp-block-navigation a:where(:not(.wp-element-button)){color: inherit;}
+:where(.wp-block-post-template.is-layout-flex){gap: 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}
+:where(.wp-block-columns.is-layout-flex){gap: 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}
+.wp-block-pullquote{font-size: 1.5em;line-height: 1.6;}
+</style>
+<link rel='stylesheet' id='wpml-legacy-dropdown-click-0-css' href='https://www.bakels.com.au/wp-content/plugins/sitepress-multilingual-cms/templates/language-switchers/legacy-dropdown-click/style.min.css?ver=1' type='text/css' media='all' />
+<link rel='stylesheet' id='tablepress-default-css' href='https://www.bakels.com.au/wp-content/plugins/tablepress/css/build/default.css?ver=2.3' type='text/css' media='all' />
+<link rel='stylesheet' id='bakels-style-css' href='https://www.bakels.com.au/wp-content/themes/bakels-local/style.css?ver=9.5.4' type='text/css' media='all' />
+<link rel='stylesheet' id='wp-paginate-css' href='https://www.bakels.com.au/wp-content/plugins/wp-paginate/css/wp-paginate.css?ver=2.2.2' type='text/css' media='screen' />
+<script type="text/javascript" id="wpml-cookie-js-extra">
+/* <![CDATA[ */
+var wpml_cookies = {"wp-wpml_current_language":{"value":"en","expires":1,"path":"\/"}};
+var wpml_cookies = {"wp-wpml_current_language":{"value":"en","expires":1,"path":"\/"}};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://www.bakels.com.au/wp-content/plugins/sitepress-multilingual-cms/res/js/cookies/language-cookie.js?ver=4.6.10" id="wpml-cookie-js" defer="defer" data-wp-strategy="defer"></script>
+<script type="text/javascript" src="https://www.bakels.com.au/wp-content/plugins/sitepress-multilingual-cms/templates/language-switchers/legacy-dropdown-click/script.min.js?ver=1" id="wpml-legacy-dropdown-click-0-js"></script>
+<script type="text/javascript" src="https://www.bakels.com.au/wp-includes/js/jquery/jquery.min.js?ver=3.7.1" id="jquery-core-js"></script>
+<script type="text/javascript" src="https://www.bakels.com.au/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1" id="jquery-migrate-js"></script>
+<script type="text/javascript" id="country-mobile-js-extra">
+/* <![CDATA[ */
+var ajax_bakels_country = {"ajaxurl":"https:\/\/www.bakels.com.au\/wp-admin\/admin-ajax.php","redirecturl":"\/recipes\/plant-based-burger-patty-using-bakels-plant-based-savoury-mix\/","loadingmessage":"Loading..."};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/js/country-mobile.min.js?ver=1.0" id="country-mobile-js"></script>
+<script></script><link rel="https://api.w.org/" href="https://www.bakels.com.au/wp-json/" /><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://www.bakels.com.au/xmlrpc.php?rsd" />
+<link rel='shortlink' href='https://www.bakels.com.au/?p=17953' />
+<link rel="alternate" type="application/json+oembed" href="https://www.bakels.com.au/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.bakels.com.au%2Frecipes%2Fplant-based-burger-patty-using-bakels-plant-based-savoury-mix%2F" />
+<link rel="alternate" type="text/xml+oembed" href="https://www.bakels.com.au/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.bakels.com.au%2Frecipes%2Fplant-based-burger-patty-using-bakels-plant-based-savoury-mix%2F&#038;format=xml" />
+
+<link rel='stylesheet' id='17910-css' href='//www.bakels.com.au/wp-content/uploads/sites/21/custom-css-js/17910.css?v=5730' type="text/css" media='all' />
+<meta name="generator" content="WPML ver:4.6.10 stt:1;" />
+<!-- Stream WordPress user activity plugin v4.0.0 -->
+
+<!-- Google Tag Manager for WordPress by gtm4wp.com -->
+<!-- GTM Container placement set to manual -->
+<script data-cfasync="false" data-pagespeed-no-defer>
+	var dataLayer_content = {"pagePostType":"recipes","pagePostType2":"single-recipes","pagePostAuthor":"australianbakels"};
+	dataLayer.push( dataLayer_content );
+</script>
+<script data-cfasync="false">
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-M2W9L34');
+</script>
+<!-- End Google Tag Manager for WordPress by gtm4wp.com -->	<script>
+	// Search Market
+	function searchMarkets() {
+		// Declare variables
+		var input, filter, ul, li, a, i, txtValue;
+		input = document.getElementById('search-markets');
+		filter = input.value.toUpperCase();
+		ul = document.getElementById("markets");
+		li = ul.getElementsByTagName('li');
+
+		// Loop through all list items, and hide those who don't match the search query
+		for (i = 0; i < li.length; i++) {
+			a = li[i].getElementsByTagName("a")[0];
+			txtValue = a.textContent || a.innerText;
+			if (txtValue.toUpperCase().indexOf(filter) > -1) {
+			li[i].style.display = "";
+			} else {
+			li[i].style.display = "none";
+			}
+		}
+	}
+
+	function mobilsearcheMarkets() {
+		// Declare variables
+		var input, filter, ul, li, a, i, txtValue;
+		input = document.getElementById('mobile-search-markets');
+		filter = input.value.toUpperCase();
+		ul = document.getElementById("mobile-markets");
+		li = ul.getElementsByTagName('li');
+
+		// Loop through all list items, and hide those who don't match the search query
+		for (i = 0; i < li.length; i++) {
+			a = li[i].getElementsByTagName("a")[0];
+			txtValue = a.textContent || a.innerText;
+			if (txtValue.toUpperCase().indexOf(filter) > -1) {
+			li[i].style.display = "";
+			} else {
+			li[i].style.display = "none";
+			}
+		}
+	}
+
+	// Search Market
+	function searchStockist() {
+		// Declare variables
+		var containerArr = ['tab-stockists', 'stockists'];
+		containerArr.forEach(function(id) {
+			var container, input, filter, ul, li, i, company, companyValue, sku, skuValue, packsize, packsizeValue;
+			container = document.getElementById(id);
+			input = container.querySelector('#search-stockist');
+			filter = input.value.toUpperCase();
+			ul = container.querySelector('#stockist');
+			li = ul.querySelectorAll('.stockist-row');
+
+			// Loop through all list items, and hide those who don't match the search query
+			for (i = 0; i < li.length; i++) {
+				company = li[i].querySelector('.stockist-company');
+				companyValue = company.textContent || company.innerText;
+
+				sku = li[i].querySelector('.stockist-sku');
+				skuValue = sku.textContent || sku.innerText;
+
+				packsize = li[i].querySelector('.pack-size');
+				packsizeValue = packsize.textContent || packsize.innerText;
+
+				if ( companyValue.toUpperCase().indexOf(filter) > -1 || skuValue.toUpperCase().indexOf(filter) > -1 || packsizeValue.toUpperCase().indexOf(filter) > -1) {
+					li[i].style.display = "";
+				} else {
+					li[i].style.display = "none";
+				}
+			}
+		});
+	}
+	</script>
+		<script>
+	// Search Options
+	function searchFilter(input = null) {
+		// Declare variables
+		var filter, tax, parent, ul, li, label, i, txtValue, clearText;
+
+		var getArrayFromTag = function(element, tagname) {
+			//get the NodeList and transform it into an array
+			return Array.prototype.slice.call(element.getElementsByTagName(tagname));
+		}
+
+		filter = input.value.toUpperCase();
+		tax = input.dataset.tax;
+		parent = document.getElementById('field-option-'+tax);
+		clearText = parent.querySelector('.clear-text');
+		ul = parent.querySelector('.option-list');
+		li = getArrayFromTag(ul, 'li');
+
+		// Loop through all list items, and hide those who don't match the search query
+		for (i = 0; i < li.length; i++) {
+			label = li[i].getElementsByTagName('span')[0];
+			txtValue = label.textContent || label.innerText;
+
+			if (txtValue.toUpperCase().indexOf(filter) > -1) {
+				li[i].style.display = "";
+			} else {
+				// Declare child variables
+				var displayParent = 0, ulChild, liChild, j, labelChild, txtValueChild;
+
+				ulChild = li[i].querySelector('.suboption-list');
+
+				if( ulChild ) {
+					liChild = getArrayFromTag(ulChild, 'li');
+					for (j = 0; j < liChild.length; j++) {
+						labelChild = liChild[j].getElementsByTagName('span')[0];
+						txtValueChild = labelChild.textContent || labelChild.innerText;
+
+						if (txtValueChild.toUpperCase().indexOf(filter) > -1) {
+							liChild[j].style.display = "";
+
+							displayParent = 1;
+						} else {
+							liChild[j].style.display = "none";
+						}
+					}
+
+					if( displayParent == 0 ) {
+						li[i].style.display = "none";
+					} else {
+						li[i].style.display = "";
+					}
+				} else {
+					li[i].style.display = "none";
+				}
+			}
+		}
+
+
+		// Show button
+		if( input.value.length > 0 ) {
+			if( !clearText.classList.contains('clear-text-show') ) {
+				clearText.classList.add('clear-text-show');
+			}
+		} else {
+			clearText.classList.remove('clear-text-show');
+		}
+
+		// Clear text
+		clearText.addEventListener('click', function(e){
+			input.value = '';
+			e.target.classList.remove('clear-text-show');
+		}, false);
+	}
+	</script>
+	<script type='text/javascript'>
+                    var imdmsTypeaheadJSON = 'typeaheadJSON_en';
+                    localStorage.setItem( 'typeaheadJSON_en', JSON.stringify( [{"id":17426,"title":"4 Seed Bread (Using Bakels 4 Seed Bread Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/4-seed-bread-using-bakels-4-seed-bread-concentrate\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15681,"title":"Actiwhite","url":"https:\/\/www.bakels.com.au\/products\/actiwhite\/","post_type":"Products","tax_terms":"Meringue and Mallow Mixes","sku":"311002","access_levels":"public_access"},{"id":15527,"title":"Advance 1000 Improver","url":"https:\/\/www.bakels.com.au\/products\/advance-1000-improver\/","post_type":"Products","tax_terms":"Bread Improvers","sku":"253352","access_levels":"public_access"},{"id":29033,"title":"Advance 300 Improver","url":"https:\/\/www.bakels.com.au\/products\/advance-300-improver\/","post_type":"Products","tax_terms":"Bread Improvers","sku":"253332","access_levels":"public_access"},{"id":15530,"title":"Advance 500 Improver","url":"https:\/\/www.bakels.com.au\/products\/advance-500-improver\/","post_type":"Products","tax_terms":"Bread Improvers","sku":"253555","access_levels":"public_access"},{"id":28878,"title":"Afghan Cookie","url":"https:\/\/www.bakels.com.au\/products\/afghan-cookie\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"632693","access_levels":"public_access"},{"id":16814,"title":"All In Sponge Mix (Using Bakels All-In Sponge Mix","url":"https:\/\/www.bakels.com.au\/recipes\/all-in-sponge-mix-using-bakels-all-in-sponge-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":15562,"title":"All Purpose Vegetable Shortening","url":"https:\/\/www.bakels.com.au\/products\/all-purpose-vegetable-shortening\/","post_type":"Products","tax_terms":"Fats & Oils","sku":"166141","access_levels":"public_access"},{"id":15761,"title":"Almond Delight Slice","url":"https:\/\/www.bakels.com.au\/recipes\/almond-delight-slice\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":15750,"title":"Alpine White Mud Cake","url":"https:\/\/www.bakels.com.au\/recipes\/alpine-white-mud-cake\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":17147,"title":"American Cake Muffins (Bakels Creme Cake Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/american-cake-muffins-bakels-creme-cake-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17896,"title":"American Rye Bread Mix","url":"https:\/\/www.bakels.com.au\/products\/american-rye-bread-mix\/","post_type":"Products","tax_terms":"Bread Mixes and Concentrates","sku":"391401","access_levels":"public_access"},{"id":28874,"title":"ANZAC Biscuit","url":"https:\/\/www.bakels.com.au\/products\/anzac-biscuit\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"632204 (40g), 661052 (29g), 661054 (25g)","access_levels":"public_access"},{"id":15663,"title":"Apito Chocolate Flavour Paste","url":"https:\/\/www.bakels.com.au\/products\/apito-chocolate-flavour-paste\/","post_type":"Products","tax_terms":"Flavouring Pastes, Essences & Colours","sku":"438002, 438001","access_levels":"public_access"},{"id":17337,"title":"Apito Essences - Bun Spice","url":"https:\/\/www.bakels.com.au\/products\/apito-essences-bun-spice\/","post_type":"Products","tax_terms":"Flavouring Pastes, Essences & Colours","sku":"453003","access_levels":"public_access"},{"id":15667,"title":"Apito Essences - Butta Vanilla","url":"https:\/\/www.bakels.com.au\/products\/apito-essences-butta-vanilla\/","post_type":"Products","tax_terms":"Flavouring Pastes, Essences & Colours","sku":"447502","access_levels":"public_access"},{"id":17332,"title":"Apito Essences - Vanilla 101","url":"https:\/\/www.bakels.com.au\/products\/apito-essences-vanilla-101\/","post_type":"Products","tax_terms":"Flavouring Pastes, Essences & Colours","sku":"452104","access_levels":"public_access"},{"id":17325,"title":"Apito Flavouring Paste - Banana","url":"https:\/\/www.bakels.com.au\/products\/apito-flavouring-paste-banana\/","post_type":"Products","tax_terms":"Flavouring Pastes, Essences & Colours","sku":"447003","access_levels":"public_access"},{"id":15662,"title":"Apito Flavouring Paste - Caramel","url":"https:\/\/www.bakels.com.au\/products\/apito-flavouring-paste-caramel\/","post_type":"Products","tax_terms":"Flavouring Pastes, Essences & Colours","sku":"431102, 431103","access_levels":"public_access"},{"id":17285,"title":"Apito Flavouring Paste - Coffee","url":"https:\/\/www.bakels.com.au\/products\/apito-flavouring-paste-coffee\/","post_type":"Products","tax_terms":"Flavouring Pastes, Essences & Colours","sku":"437003","access_levels":"public_access"},{"id":17250,"title":"Apito Flavouring Paste - Lemon","url":"https:\/\/www.bakels.com.au\/products\/apito-flavouring-paste-lemon\/","post_type":"Products","tax_terms":"Flavouring Pastes, Essences & Colours","sku":"431002, 431003","access_levels":"public_access"},{"id":17274,"title":"Apito Flavouring Paste - Mango","url":"https:\/\/www.bakels.com.au\/products\/apito-flavouring-paste-mango\/","post_type":"Products","tax_terms":"Flavouring Pastes, Essences & Colours","sku":"435202","access_levels":"public_access"},{"id":17861,"title":"Apito Flavouring Paste - Orange","url":"https:\/\/www.bakels.com.au\/products\/apito-flavouring-paste-orange\/","post_type":"Products","tax_terms":"Flavouring Pastes, Essences & Colours","sku":"433002, 433003","access_levels":"public_access"},{"id":17894,"title":"Apito Flavouring Paste - Orange (Halal)","url":"https:\/\/www.bakels.com.au\/products\/apito-flavouring-paste-orange-halal\/","post_type":"Products","tax_terms":"Flavouring Pastes, Essences & Colours","sku":"433021","access_levels":"public_access"},{"id":15773,"title":"Apito Flavouring Paste - Raspberry","url":"https:\/\/www.bakels.com.au\/products\/apito-flavouring-paste-raspberry\/","post_type":"Products","tax_terms":"Flavouring Pastes, Essences & Colours","sku":"442003","access_levels":null},{"id":17262,"title":"Apito Flavouring Paste - Rum","url":"https:\/\/www.bakels.com.au\/products\/apito-flavouring-paste-rum\/","post_type":"Products","tax_terms":"Flavouring Pastes, Essences & Colours","sku":"435004","access_levels":"public_access"},{"id":15774,"title":"Apito Flavouring Paste - Strawberry","url":"https:\/\/www.bakels.com.au\/products\/apito-flavouring-paste-strawberry\/","post_type":"Products","tax_terms":"Flavouring Pastes, Essences & Colours","sku":"441003","access_levels":"public_access"},{"id":17217,"title":"Apito Superglaze","url":"https:\/\/www.bakels.com.au\/products\/apito-superglaze\/","post_type":"Products","tax_terms":"Glazes, Piping Gels & Dips","sku":"346102","access_levels":"public_access"},{"id":17209,"title":"Apito Superglaze - Apricot","url":"https:\/\/www.bakels.com.au\/products\/apito-superglaze-apricot\/","post_type":"Products","tax_terms":"Glazes, Piping Gels & Dips","sku":"346002","access_levels":"public_access"},{"id":15586,"title":"Apito Utility Cake Mix","url":"https:\/\/www.bakels.com.au\/products\/apito-utility-cake-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"382601","access_levels":"public_access"},{"id":16896,"title":"Apple & Cinnamon Muffin (Using Bakels Vegan Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/apple-cinnamon-muffin-using-bakels-vegan-cake-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17328,"title":"Apple and Blueberry Flan Filling - No Cook Method (Using Pettina Apple and Blueberry Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/apple-and-blueberry-flan-filling-no-cook-method-using-pettina-apple-and-blueberry-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17135,"title":"Apple and Sultana Cake (Using Bakels Homestyle Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/apple-and-sultana-cake-using-bakels-homestyle-cake-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":16998,"title":"Apple and Walnut Cake (Using Bakels Homestyle Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/apple-and-walnut-cake-using-bakels-homestyle-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17140,"title":"Apple Cinnamon Cake Muffin (Using Bakels All-In Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/apple-cinnamon-cake-muffin-using-bakels-all-in-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16924,"title":"Apple Cinnamon Cake Muffins (Using Bakels Creme Cake Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/apple-cinnamon-cake-muffins-using-bakels-creme-cake-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15735,"title":"Apple Cinnamon Filling","url":"https:\/\/www.bakels.com.au\/recipes\/apple-cinnamon-filling\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17326,"title":"Apple Filling (Using Pettina Apple Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/apple-filling-using-pettina-apple-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16872,"title":"Apple Pie Filling - No Cook Method (Using Bakels Instant Starch)","url":"https:\/\/www.bakels.com.au\/recipes\/apple-pie-filling-using-bakels-instant-starch\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17424,"title":"Apple, Sultana and Hazelnut Loaf (Using Artisan 7% Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/apple-sultana-and-hazelnut-loaf-using-artisan-7-concentrate\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":28865,"title":"Apricot & Almond Cookie","url":"https:\/\/www.bakels.com.au\/products\/apricot-almond-cookie\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"631504","access_levels":"public_access"},{"id":17242,"title":"Apricot and Almond Slice (Using Bakels Neutral Hedgehog Slice Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/apricot-and-almond-slice-using-bakels-neutral-hedgehog-slice-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":"public_access"},{"id":17396,"title":"Apricot and Coconut Slice (Using Pettina Kokomix)","url":"https:\/\/www.bakels.com.au\/recipes\/apricot-and-coconut-slice-using-pettina-kokomix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16939,"title":"Apricot and Pecan Cake (Using Bakels Homestyle Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/apricot-and-pecan-cake-using-bakels-homestyle-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16804,"title":"Apricot Bavarian (Using Bavarian Supreme)","url":"https:\/\/www.bakels.com.au\/recipes\/apricot-bavarian-using-bavarian-supreme\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16960,"title":"Apricot Downunder Cake (Using Bakels Chocolate Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/apricot-downunder-cake-using-bakels-chocolate-muffin-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":16964,"title":"Apricot Loaf (Using Fruit and Nut Loaf Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/apricot-loaf-using-fruit-and-nut-loaf-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17307,"title":"Apricot Torte\/Cheesecake (Using Bakels Gourmet Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/apricot-torte-cheesecake-using-gourmet-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17306,"title":"Apricot Torte\/Cheesecake (Using Pettina Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/apricot-torte-cheesecake-using-pettina-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17825,"title":"Artisan 7% Concentrate","url":"https:\/\/www.bakels.com.au\/products\/artisan-7-concentrate\/","post_type":"Products","tax_terms":"Bread Mixes and Concentrates","sku":"394102","access_levels":"public_access"},{"id":16824,"title":"Artisan Bread (Using Bakels Fermdor R Classic)","url":"https:\/\/www.bakels.com.au\/recipes\/artisan-bread-using-bakels-fermdor-r-classic\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16859,"title":"Artisan Bread (Using Bakels Fermdor W Classic)","url":"https:\/\/www.bakels.com.au\/recipes\/artisan-bread-using-bakels-fermdor-w-classic\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17212,"title":"Artisan Bread with Apricot and Almond (Using Bakels Fermdor W Classic)","url":"https:\/\/www.bakels.com.au\/recipes\/artisan-bread-with-apricot-and-almond-using-bakels-fermdor-w-classic\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16871,"title":"Artisan Bread with Apricot and Almond (Using Fermdor W Classic)","url":"https:\/\/www.bakels.com.au\/recipes\/artisan-bread-with-apricot-and-almond-using-fermdor-w-classic\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17225,"title":"Artisan Bread with Fig (Using Bakels Fermdor W Classic)","url":"https:\/\/www.bakels.com.au\/recipes\/artisan-bread-with-fig-using-bakels-fermdor-w-classic\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16825,"title":"Artisan Bread with Hazelnut and Sultana (Using Bakels Fermdor W Classic)","url":"https:\/\/www.bakels.com.au\/recipes\/artisan-bread-with-hazelnut-and-sultana-using-bakels-fermdor-w-classic\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16826,"title":"Artisan Bread with Olives (Using Bakels Fermdor W Classic)","url":"https:\/\/www.bakels.com.au\/recipes\/artisan-bread-with-olives-using-bakels-fermdor-w-classic\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17227,"title":"Artisan Grain Bread (Using Bakels Fermdor W Classic)","url":"https:\/\/www.bakels.com.au\/recipes\/artisan-grain-bread-using-bakels-fermdor-w-classic\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17447,"title":"Artisan Hot Cross Buns (Using Artisan 7% Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/artisan-hot-cross-buns-using-artisan-7-concentrate\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15776,"title":"Asian Sweet Bread","url":"https:\/\/www.bakels.com.au\/recipes\/asian-sweet-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3391,"title":"Australia","url":"https:\/\/www.bakels.com.au\/services\/baking-centres\/australia\/","post_type":"Baking Centres","access_levels":null},{"id":15517,"title":"Bacom A100","url":"https:\/\/www.bakels.com.au\/products\/bacom-a100\/","post_type":"Products","tax_terms":"Specialised Fats","sku":"218001","access_levels":"public_access"},{"id":17450,"title":"Baguette (Using Artisan 7% Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/baguette-using-artisan-7-concentrate\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17295,"title":"Baked Cheesecake - Alternative Recipe (Using Bakels Gourmet Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/baked-cheesecake-alternative-recipe-using-bakels-gourmet-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17354,"title":"Baked Cheesecake - Alternative Recipe (Using Pettina Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/baked-cheesecake-alternative-recipe-using-pettina-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17293,"title":"Baked Cheesecake (Using Bakels Gourmet Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/baked-cheesecake-using-bakels-gourmet-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17292,"title":"Baked Cheesecake Slice (Using Bakels Gourmet Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/baked-cheesecake-slice-using-bakels-gourmet-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17355,"title":"Baked Cheesecake Slice (Using Pettina Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/baked-cheesecake-slice-using-pettina-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15787,"title":"Baked Cherry Cheesecake Slice (using Bakels Gourmet Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/baked-cherry-cheesecake-slice\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17286,"title":"Baked Christmas Cheesecake (Using Bakels Gourmet Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/baked-christmas-cheesecake-using-bakels-gourmet-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15548,"title":"Bakels 4 Seed Concentrate","url":"https:\/\/www.bakels.com.au\/products\/bakels-4-seed-concentrate\/","post_type":"Products","tax_terms":"Bread Mixes and Concentrates","sku":"392201","access_levels":"public_access"},{"id":15550,"title":"Bakels Advance Bread and Roll Concentrate","url":"https:\/\/www.bakels.com.au\/products\/bakels-advance-bread-and-roll-concentrate\/","post_type":"Products","tax_terms":"Bread Mixes and Concentrates","sku":"394651","access_levels":"public_access"},{"id":17013,"title":"Bakels All In Choc Mud Cake Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-all-in-choc-mud-cake-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"384642","access_levels":"public_access"},{"id":17027,"title":"Bakels All-In Buttacake Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-all-in-buttacake-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"381202","access_levels":"public_access"},{"id":15600,"title":"Bakels All-In Choc Chunk Brownie Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-all-in-choc-chunk-brownie-mix\/","post_type":"Products","tax_terms":"Slice Mixes & Bases","sku":"383571","access_levels":"public_access"},{"id":17024,"title":"Bakels All-In Muffin Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-all-in-muffin-mix\/","post_type":"Products","tax_terms":"Muffin Mixes","sku":"382771","access_levels":"public_access"},{"id":16695,"title":"Bakels All-In Sponge Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-all-in-sponge-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"371721","access_levels":"public_access"},{"id":28946,"title":"Bakels Apple Filling 65%","url":"https:\/\/www.bakels.com.au\/products\/bakels-apple-filling\/","post_type":"Products","tax_terms":"Fruit & Fruit Flavoured Fillings","sku":"418192, 418193","access_levels":"public_access"},{"id":17341,"title":"Bakels Apple Green Colour","url":"https:\/\/www.bakels.com.au\/products\/bakels-apple-green-colour\/","post_type":"Products","tax_terms":"Flavouring Pastes, Essences & Colours","sku":"461112","access_levels":"public_access"},{"id":17103,"title":"Bakels Apricot Fruit Filling","url":"https:\/\/www.bakels.com.au\/products\/bakels-apricot-fruit-filling\/","post_type":"Products","tax_terms":"Fruit & Fruit Flavoured Fillings","sku":"418893","access_levels":"public_access"},{"id":15674,"title":"Bakels Baking Powder","url":"https:\/\/www.bakels.com.au\/products\/bakels-baking-powder\/","post_type":"Products","tax_terms":"Raising Agents","sku":"297101","access_levels":"public_access"},{"id":15547,"title":"Bakels Banana Bread Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-banana-bread-mix\/","post_type":"Products","tax_terms":"Bread Mixes and Concentrates","sku":"386341","access_levels":"public_access"},{"id":17078,"title":"Bakels Banana Cake Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-banana-cake-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"386201","access_levels":"public_access"},{"id":15546,"title":"Bakels Brioche Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-brioche-mix\/","post_type":"Products","tax_terms":"Bread Mixes and Concentrates","sku":"378592","access_levels":"public_access"},{"id":15585,"title":"Bakels Buttacake Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-buttacake-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"381301","access_levels":"public_access"},{"id":17000,"title":"Bakels Butter Bars - Chocolate Cherry (Using Pettina Chocolate Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/bakels-butter-bars-chocolate-cherry-using-pettina-chocolate-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16999,"title":"Bakels Butter Bars - Chocolate Ginger Bars (Using Pettina Chocolate Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/bakels-butter-bars-chocolate-ginger-bars-using-pettina-chocolate-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15748,"title":"Bakels Butter Bars - Golden Cherry Bars","url":"https:\/\/www.bakels.com.au\/recipes\/bakels-butter-bars-golden-cherry-bars\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":16914,"title":"Bakels Butter Bars - Golden Cherry Bars (Using Bakels All-In Buttacake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/bakels-butter-bars-golden-cherry-bars-using-bakels-all-in-buttacake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15747,"title":"Bakels Butter Bars - Luncheon Bars (Using Bakels Buttacake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/bakels-butter-bars-luncheon-bars-using-bakels-buttacake-mix\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":16934,"title":"Bakels Butter Bars - Mocha Pecan Bars (Using Pettina Chocolate Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/bakels-butter-bars-mocha-pecan-bars-using-pettina-chocolate-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17002,"title":"Bakels Butter Bars - Rum 'N' Raisin Bars (Using Pettina Chocolate Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/bakels-butter-bars-rum-n-raisin-bars-using-pettina-chocolate-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15528,"title":"Bakels C L Soft","url":"https:\/\/www.bakels.com.au\/products\/bakels-c-l-soft\/","post_type":"Products","tax_terms":"Bread Improvers","sku":"253511","access_levels":null},{"id":15529,"title":"Bakels C L Strong","url":"https:\/\/www.bakels.com.au\/products\/bakels-c-l-strong\/","post_type":"Products","tax_terms":"Bread Improvers","sku":"253521","access_levels":null},{"id":17770,"title":"Bakels Cake Donut Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-cake-donut-mix\/","post_type":"Products","tax_terms":"Donut Mixes and Concentrates","sku":"376001","access_levels":"public_access"},{"id":15671,"title":"Bakels Calcium Propionate (CSP60)","url":"https:\/\/www.bakels.com.au\/products\/bakels-calcium-propionate-csp60\/","post_type":"Products","tax_terms":"Preservatives","sku":"272502","access_levels":null},{"id":17767,"title":"Bakels Caramel Flavoured Delite Cake Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-caramel-flavoured-delite-cake-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"383201","access_levels":"public_access"},{"id":17845,"title":"Bakels Caramel Fudge Filling","url":"https:\/\/www.bakels.com.au\/products\/bakels-caramel-fudge-filling\/","post_type":"Products","tax_terms":"Caramel and Creme Fillings","sku":"414422","access_levels":"public_access"},{"id":17850,"title":"Bakels Caramel Fudge Topping","url":"https:\/\/www.bakels.com.au\/products\/bakels-caramel-fudge-topping\/","post_type":"Products","tax_terms":"Caramel and Creme Fillings, Toppings","sku":"416002","access_levels":"public_access"},{"id":15631,"title":"Bakels Caramel Truffle MB","url":"https:\/\/www.bakels.com.au\/products\/bakels-caramel-truffle-mb\/","post_type":"Products","tax_terms":"Fondants, Chocolate, Ganache & Truffles","sku":"514362","access_levels":"public_access"},{"id":17060,"title":"Bakels Caramel Truffle NAFNAC MB","url":"https:\/\/www.bakels.com.au\/products\/caramel-truffle-mb\/","post_type":"Products","tax_terms":"Fondants, Chocolate, Ganache & Truffles","sku":"514642","access_levels":"public_access"},{"id":17080,"title":"Bakels Carrot Cake Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-carrot-cake-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"386501","access_levels":"public_access"},{"id":17839,"title":"Bakels Chia Bread Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-chia-bread-mix\/","post_type":"Products","tax_terms":"Bread Mixes and Concentrates","sku":"391851","access_levels":"public_access"},{"id":15700,"title":"Bakels Choc Chip Chunky Cookie","url":"https:\/\/www.bakels.com.au\/products\/bakels-choc-chip-chunky-cookie\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"632792","access_levels":"public_access"},{"id":15696,"title":"Bakels Choc Chip Cookie","url":"https:\/\/www.bakels.com.au\/products\/bakels-choc-chip-cookie\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"632754","access_levels":"public_access"},{"id":18463,"title":"Bakels Choc Royale Sponge Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-choc-royale-sponge-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"371101","access_levels":"public_access"},{"id":15622,"title":"Bakels Choco Mousse Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-choco-mousse-mix\/","post_type":"Products","tax_terms":"Mousse Mixes","sku":"414702, 414705","access_levels":"public_access"},{"id":29312,"title":"Bakels Choco Mousse Mix NAFNAC","url":"https:\/\/www.bakels.com.au\/products\/bakels-choco-mousse-mix-nafnac\/","post_type":"Products","tax_terms":"Mousse Mixes","sku":"414731, 414732","access_levels":"public_access"},{"id":17403,"title":"Bakels Chocolate Brown Colour","url":"https:\/\/www.bakels.com.au\/products\/bakels-chocolate-brown-colour\/","post_type":"Products","tax_terms":"Flavouring Pastes, Essences & Colours","sku":"461152","access_levels":"public_access"},{"id":17848,"title":"Bakels Chocolate Fudge Topping","url":"https:\/\/www.bakels.com.au\/products\/bakels-chocolate-fudge-topping\/","post_type":"Products","tax_terms":"Caramel and Creme Fillings, Toppings","sku":"415002","access_levels":"public_access"},{"id":15630,"title":"Bakels Chocolate Ganache - MB","url":"https:\/\/www.bakels.com.au\/products\/bakels-chocolate-ganache-mb\/","post_type":"Products","tax_terms":"Fondants, Chocolate, Ganache & Truffles, Icings & Icing Sugars","sku":"514002, 514003, 514004","access_levels":"public_access"},{"id":15639,"title":"Bakels Chocolate Glaze","url":"https:\/\/www.bakels.com.au\/products\/bakels-chocolate-glaze\/","post_type":"Products","tax_terms":"Glazes, Piping Gels & Dips","sku":"346752","access_levels":"public_access"},{"id":15603,"title":"Bakels Chocolate Hedgehog Slice Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-chocolate-hedgehog-slice-mix\/","post_type":"Products","tax_terms":"Slice Mixes & Bases","sku":"386403","access_levels":"public_access"},{"id":17507,"title":"Bakels Chocolate Muffin Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-chocolate-muffin-mix\/","post_type":"Products","tax_terms":"Muffin Mixes, Cookie & Biscuit Mixes","sku":"383901","access_levels":"public_access"},{"id":17818,"title":"Bakels Ciabatta Bread Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-ciabatta-bread-mix\/","post_type":"Products","tax_terms":"Bread Mixes and Concentrates","sku":"392804","access_levels":"public_access"},{"id":17245,"title":"Bakels Cinnamon Sugar","url":"https:\/\/www.bakels.com.au\/products\/bakels-cinnamon-sugar\/","post_type":"Products","tax_terms":"Various Pastry Cooking Products","sku":"424172","access_levels":"public_access"},{"id":15567,"title":"Bakels Cook Up Starch","url":"https:\/\/www.bakels.com.au\/products\/bakels-cook-up-starch\/","post_type":"Products","tax_terms":"Specialised Pie & Potato Products","sku":"359652","access_levels":"public_access"},{"id":15694,"title":"Bakels Cookie Drops","url":"https:\/\/www.bakels.com.au\/products\/bakels-cookie-drops\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"631452","access_levels":"public_access"},{"id":17779,"title":"Bakels Cream Cheese Icing Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-cream-cheese-icing-mix\/","post_type":"Products","tax_terms":"Icings & Icing Sugars","sku":"334002","access_levels":"public_access"},{"id":15587,"title":"Bakels Creme Cake Muffin Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-creme-cake-muffin-mix\/","post_type":"Products","tax_terms":"Muffin Mixes","sku":"382801, 382807, 382808","access_levels":"public_access"},{"id":17058,"title":"Bakels Croquant Truffle","url":"https:\/\/www.bakels.com.au\/products\/bakels-croquant-truffle\/","post_type":"Products","tax_terms":"Icings & Icing Sugars","sku":"514382","access_levels":"public_access"},{"id":15520,"title":"Bakels Crossing Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-crossing-mix\/","post_type":"Products","tax_terms":"Bread Toppings","sku":"420712","access_levels":"public_access"},{"id":17789,"title":"Bakels Crossing Mix NPNTi","url":"https:\/\/www.bakels.com.au\/products\/bakels-crossing-mix-npnti\/","post_type":"Products","tax_terms":"Bread Toppings","sku":"329302","access_levels":null},{"id":17796,"title":"Bakels Crumble Topping Mix NAFNAC","url":"https:\/\/www.bakels.com.au\/products\/bakels-crumble-topping-mix-nafnac\/","post_type":"Products","tax_terms":"Various Pastry Cooking Products","sku":"379882","access_levels":"public_access"},{"id":15619,"title":"Bakels Custard Tart Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-custard-tart-mix\/","post_type":"Products","tax_terms":"Custard and Creme Mixes","sku":"332001","access_levels":"public_access"},{"id":15555,"title":"Bakels Danish and Croissant Margarine - NAFNAC","url":"https:\/\/www.bakels.com.au\/products\/danish-and-croissant-pastry-margarine\/","post_type":"Products","tax_terms":"Pastry Margarines","sku":"166104","access_levels":"public_access"},{"id":17351,"title":"Bakels Dark Blue Colour","url":"https:\/\/www.bakels.com.au\/products\/bakels-dark-blue-colour\/","post_type":"Products","tax_terms":"Flavouring Pastes, Essences & Colours","sku":"461122","access_levels":"public_access"},{"id":15638,"title":"Bakels Diamond Glaze All Round","url":"https:\/\/www.bakels.com.au\/products\/bakels-diamond-glaze-all-round-neutral\/","post_type":"Products","tax_terms":"Glazes, Piping Gels & Dips","sku":"345622","access_levels":"public_access"},{"id":15526,"title":"Bakels Dobrim 500 Improver","url":"https:\/\/www.bakels.com.au\/products\/bakels-dobrim-500-improver\/","post_type":"Products","tax_terms":"Bread Improvers","sku":"253302","access_levels":"public_access"},{"id":15643,"title":"Bakels Donut Glaze","url":"https:\/\/www.bakels.com.au\/products\/bakels-donut-glaze\/","post_type":"Products","tax_terms":"Glazes, Piping Gels & Dips","sku":"426165","access_levels":"public_access"},{"id":15697,"title":"Bakels Double Choc Cookie","url":"https:\/\/www.bakels.com.au\/products\/bakels-double-choc-cookie\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"632804","access_levels":"public_access"},{"id":15536,"title":"Bakels Dovidol","url":"https:\/\/www.bakels.com.au\/products\/dovidol\/","post_type":"Products","tax_terms":"Fats & Oils, Release Solutions","sku":"132124","access_levels":"public_access"},{"id":28894,"title":"Bakels Dulce de Leche","url":"https:\/\/www.bakels.com.au\/products\/bakels-dulce-de-leche\/","post_type":"Products","tax_terms":"Caramel and Creme Fillings","sku":"471852","access_levels":"public_access"},{"id":17075,"title":"Bakels European Muffin Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-european-muffin-mix\/","post_type":"Products","tax_terms":"Muffin Mixes, Cookie & Biscuit Mixes","sku":"384351","access_levels":"public_access"},{"id":15523,"title":"Bakels Extra 1% Improver","url":"https:\/\/www.bakels.com.au\/products\/bakels-extra-1-improver\/","post_type":"Products","tax_terms":"Bread Improvers","sku":"197201","access_levels":"public_access"},{"id":29048,"title":"Bakels Fermdor R Classic","url":"https:\/\/www.bakels.com.au\/products\/bakels-fermdor-r-classic\/","post_type":"Products","tax_terms":"Sourdough Products","sku":"361533","access_levels":"public_access"},{"id":29040,"title":"Bakels Fermdor Rustic","url":"https:\/\/www.bakels.com.au\/products\/bakels-fermdor-rustic\/","post_type":"Products","tax_terms":"Sourdough Products","sku":"361642","access_levels":"public_access"},{"id":15540,"title":"Bakels Fermdor W Classic","url":"https:\/\/www.bakels.com.au\/products\/bakels-fermdor-wm\/","post_type":"Products","tax_terms":"Sourdough Products","sku":"361552, 361553","access_levels":"public_access"},{"id":17800,"title":"Bakels Flourless Almond Cake Mix MB","url":"https:\/\/www.bakels.com.au\/products\/bakels-flourless-almond-cake-mix-15kg\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"383541","access_levels":"public_access"},{"id":17391,"title":"Bakels French Pink Colour","url":"https:\/\/www.bakels.com.au\/products\/bakels-french-pink-colour\/","post_type":"Products","tax_terms":"Flavouring Pastes, Essences & Colours","sku":"461132","access_levels":"public_access"},{"id":17005,"title":"Bakels Fruit Cake Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-fruit-cake-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"382201","access_levels":"public_access"},{"id":18455,"title":"Bakels Gingerbread Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-gingerbread-mix\/","post_type":"Products","tax_terms":"Various Pastry Cooking Products","sku":"379551","access_levels":null},{"id":15583,"title":"Bakels Gluten Free Artisan Bread Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-gluten-free-artisan-bread-mix\/","post_type":"Products","tax_terms":"Gluten Free Products","sku":"393222","access_levels":"public_access"},{"id":15581,"title":"Bakels Gluten Free Bread Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-gluten-free-bread-mix\/","post_type":"Products","tax_terms":"Gluten Free Products","sku":"393202, 393201","access_levels":"public_access"},{"id":15579,"title":"Bakels Gluten Free Health Baking Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-gluten-free-health-baking-mix\/","post_type":"Products","tax_terms":"Gluten Free Products","sku":"297372","access_levels":"public_access"},{"id":15580,"title":"Bakels Gluten Free Health Flour","url":"https:\/\/www.bakels.com.au\/products\/bakels-gluten-free-health-flour\/","post_type":"Products","tax_terms":"Gluten Free Products","sku":"393142","access_levels":"public_access"},{"id":17083,"title":"Bakels Gourmet Carrot Cake Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-gourmet-carrot-cake-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"386672","access_levels":"public_access"},{"id":17164,"title":"Bakels Gourmet Cheesecake Mix MB","url":"https:\/\/www.bakels.com.au\/products\/bakels-gourmet-cheesecake-mix-mb\/","post_type":"Products","tax_terms":"Cheesecake Mixes","sku":"579104","access_levels":"public_access"},{"id":17765,"title":"Bakels Homestyle Cake Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-homestyle-cake-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"383401","access_levels":"public_access"},{"id":16697,"title":"Bakels Honey Roll Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-honey-roll-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"375221","access_levels":"public_access"},{"id":15660,"title":"Bakels Icing Stabiliser","url":"https:\/\/www.bakels.com.au\/products\/bakels-icing-stabiliser\/","post_type":"Products","tax_terms":"Icings & Icing Sugars","sku":"422551","access_levels":"public_access"},{"id":15659,"title":"Bakels Icing Sugar Mixture","url":"https:\/\/www.bakels.com.au\/products\/bakels-icing-sugar-mixture\/","post_type":"Products","tax_terms":"Icings & Icing Sugars","sku":"422501","access_levels":"public_access"},{"id":15533,"title":"Bakels Instant Active Dry Yeast (Angel)","url":"https:\/\/www.bakels.com.au\/products\/bakels-instant-active-dry-yeast-angel\/","post_type":"Products","tax_terms":"Yeast","sku":"293903","access_levels":"public_access"},{"id":15621,"title":"Bakels Instant Continental Custard Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-instant-continental-custard-mix\/","post_type":"Products","tax_terms":"Custard and Creme Mixes","sku":"336606","access_levels":"public_access"},{"id":17806,"title":"Bakels Instant Continental Custard Mix NAFNAC","url":"https:\/\/www.bakels.com.au\/products\/bakels-instant-continental-custard-mix-nafnac\/","post_type":"Products","tax_terms":"Custard and Creme Mixes","sku":"336612","access_levels":"public_access"},{"id":15758,"title":"Bakels Instant Creme Mix","url":"https:\/\/www.bakels.com.au\/recipes\/bakels-instant-creme-mix\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":15594,"title":"Bakels Instant Cr\u00e8me Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-instant-creme-mix\/","post_type":"Products","tax_terms":"Caramel and Creme Fillings","sku":"414202","access_levels":"public_access"},{"id":15620,"title":"Bakels Instant Custard Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-instant-custard-mix\/","post_type":"Products","tax_terms":"Custard and Creme Mixes","sku":"336503","access_levels":"public_access"},{"id":17773,"title":"Bakels Instant Snowflake Custard Mix NAFNAC","url":"https:\/\/www.bakels.com.au\/products\/bakels-instant-snowflake-custard-mix-nafnac\/","post_type":"Products","tax_terms":"Custard and Creme Mixes","sku":"366512","access_levels":"public_access"},{"id":15566,"title":"Bakels Instant Starch","url":"https:\/\/www.bakels.com.au\/products\/bakels-instant-starch\/","post_type":"Products","tax_terms":"Specialised Pie & Potato Products","sku":"359641","access_levels":"public_access"},{"id":15607,"title":"Bakels Lemon Cr\u00e8me","url":"https:\/\/www.bakels.com.au\/products\/bakels-lemon-creme\/","post_type":"Products","tax_terms":"Fruit & Fruit Flavoured Fillings","sku":"414372","access_levels":"public_access"},{"id":15611,"title":"Bakels Lemon Curd Filling","url":"https:\/\/www.bakels.com.au\/products\/bakels-lemon-curd-filling\/","post_type":"Products","tax_terms":"Fruit & Fruit Flavoured Fillings","sku":"418403","access_levels":"public_access"},{"id":28957,"title":"Bakels Lemon Curd Natural","url":"https:\/\/www.bakels.com.au\/products\/bakels-lemon-curd-natural\/","post_type":"Products","tax_terms":"Fruit & Fruit Flavoured Fillings","sku":"418502, 418503","access_levels":"public_access"},{"id":17097,"title":"Bakels Lemon Flavoured Filling","url":"https:\/\/www.bakels.com.au\/products\/bakels-lemon-flavoured-filling\/","post_type":"Products","tax_terms":"Fruit & Fruit Flavoured Fillings","sku":"418102","access_levels":"public_access"},{"id":17399,"title":"Bakels Lemon Yellow Colour","url":"https:\/\/www.bakels.com.au\/products\/bakels-lemon-yellow-colour\/","post_type":"Products","tax_terms":"Flavouring Pastes, Essences & Colours","sku":"461142","access_levels":"public_access"},{"id":15610,"title":"Bakels Les Fruits 50% Raspberry Filling","url":"https:\/\/www.bakels.com.au\/products\/bakels-les-fruits-50-raspberry-filling\/","post_type":"Products","tax_terms":"Fruit & Fruit Flavoured Fillings","sku":"418283","stockist_sku":"","access_levels":"public_access"},{"id":17749,"title":"Bakels Light Fruit Cake Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-light-fruit-cake-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"382151","access_levels":"public_access"},{"id":17754,"title":"Bakels Lite Cake Muffin Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-lite-cake-muffin-mix\/","post_type":"Products","tax_terms":"Muffin Mixes, Cookie & Biscuit Mixes","sku":"382401","access_levels":"public_access"},{"id":15684,"title":"Bakels Macaron Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-macaron-mix\/","post_type":"Products","tax_terms":"Meringue and Mallow Mixes","sku":"317012","access_levels":"public_access"},{"id":15569,"title":"Bakels Meat Pie Mix Complete","url":"https:\/\/www.bakels.com.au\/products\/bakels-meat-pie-mix-complete\/","post_type":"Products","tax_terms":"Specialised Pie & Potato Products","sku":"731502","access_levels":"public_access"},{"id":15698,"title":"Bakels Melting Moments","url":"https:\/\/www.bakels.com.au\/products\/bakels-melting-moments\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"632852","access_levels":"public_access"},{"id":17180,"title":"Bakels Milk Choc Ganache MB","url":"https:\/\/www.bakels.com.au\/products\/bakels-milk-choc-ganache-mb\/","post_type":"Products","tax_terms":"Icings & Icing Sugars","sku":"514162","access_levels":"public_access"},{"id":15612,"title":"Bakels Millionaires Caramel","url":"https:\/\/www.bakels.com.au\/products\/bakels-millionaires-caramel\/","post_type":"Products","tax_terms":"Caramel and Creme Fillings","sku":"471812, 471813","access_levels":"public_access"},{"id":15589,"title":"Bakels Millionaires Mud Cake Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-millionaires-mud-cake-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"383751","access_levels":"public_access"},{"id":15588,"title":"Bakels Mud Cake Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-mud-cake-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"383501","access_levels":"public_access"},{"id":18044,"title":"Bakels Muffin Concentrate","url":"https:\/\/www.bakels.com.au\/products\/bakels-muffin-concentrate\/","post_type":"Products","tax_terms":"Muffin Mixes","sku":"382743","access_levels":"public_access"},{"id":29056,"title":"Bakels Multi-Fibre Muffin Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-multi-fibre-muffin-mix\/","post_type":"Products","tax_terms":"Muffin Mixes","sku":"382901","access_levels":"public_access"},{"id":15584,"title":"Bakels Multi-Purpose Sponge Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-multi-purpose-sponge-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"371371","access_levels":"public_access"},{"id":15551,"title":"Bakels Multiseed Bread Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-multiseed-bread-mix\/","post_type":"Products","tax_terms":"Bread Mixes and Concentrates","sku":"394752","access_levels":"public_access"},{"id":15765,"title":"Bakels Neutral Hedgehog Slice Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-neutral-hedgehog-slice-mix\/","post_type":"Products","tax_terms":"Slice Mixes & Bases","sku":"386462","access_levels":"public_access"},{"id":15591,"title":"Bakels Orange and Poppy Seed Muffin Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-orange-and-poppy-seed-muffin-mix\/","post_type":"Products","tax_terms":"Muffin Mixes","sku":"384301","access_levels":"public_access"},{"id":28951,"title":"Bakels Passionfruit Curd","url":"https:\/\/www.bakels.com.au\/products\/bakels-passionfruit-curd\/","post_type":"Products","tax_terms":"Fruit & Fruit Flavoured Fillings","sku":"418522","access_levels":"public_access"},{"id":15564,"title":"Bakels Pastry Relaxer","url":"https:\/\/www.bakels.com.au\/products\/bakels-pastry-relaxer\/","post_type":"Products","tax_terms":"Specialised Pie & Potato Products","sku":"261001","access_levels":"public_access"},{"id":15613,"title":"Bakels Pie Fillings - Blueberry 50%","url":"https:\/\/www.bakels.com.au\/products\/bakels-pie-filling-blueberry-50\/","post_type":"Products","tax_terms":"Fruit & Fruit Flavoured Fillings","sku":"586104","access_levels":"public_access"},{"id":15614,"title":"Bakels Pie Fillings - Dark Cherry 50%","url":"https:\/\/www.bakels.com.au\/products\/bakels-pie-fillings-dark-cherry-50\/","post_type":"Products","tax_terms":"Fruit & Fruit Flavoured Fillings","sku":"586304","access_levels":"public_access"},{"id":16414,"title":"Bakels Pie Fillings - Strawberry 50%","url":"https:\/\/www.bakels.com.au\/products\/bakels-pie-fillings-strawberry-50\/","post_type":"Products","tax_terms":"Fruit & Fruit Flavoured Fillings","sku":"586204","access_levels":"public_access"},{"id":15669,"title":"Bakels Pillar Box Red Colour","url":"https:\/\/www.bakels.com.au\/products\/bakels-pillar-box-red-colour\/","post_type":"Products","tax_terms":"Flavouring Pastes, Essences & Colours","sku":"461162","access_levels":"public_access"},{"id":18046,"title":"Bakels Plant-Based Yeast Raised Donut Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-plant-based-yeast-raised-donut-mix\/","post_type":"Products","tax_terms":"Donut Mixes and Concentrates","sku":"376242","access_levels":"public_access"},{"id":18441,"title":"Bakels Powdered Donut Glaze","url":"https:\/\/www.bakels.com.au\/products\/bakels-powdered-donut-glaze\/","post_type":"Products","tax_terms":"Glazes, Piping Gels & Dips","sku":"345672","access_levels":null},{"id":15685,"title":"Bakels Puff Pastry Block","url":"https:\/\/www.bakels.com.au\/products\/puff-pastry-block\/","post_type":"Products","tax_terms":"Frozen Pastry","sku":"611352","access_levels":null},{"id":15521,"title":"Bakels Quantum CL 1000 Improver","url":"https:\/\/www.bakels.com.au\/products\/bakels-quantum-cl-1000-improver\/","post_type":"Products","tax_terms":"Bread Improvers","sku":"195402","access_levels":"public_access"},{"id":15522,"title":"Bakels Quantum Plus Improver","url":"https:\/\/www.bakels.com.au\/products\/bakels-quantum-plus-improver\/","post_type":"Products","tax_terms":"Bread Improvers","sku":"195452","access_levels":"public_access"},{"id":15609,"title":"Bakels Rasplum Filling","url":"https:\/\/www.bakels.com.au\/products\/bakels-rasplum-filling\/","post_type":"Products","tax_terms":"Fruit & Fruit Flavoured Fillings","sku":"418232, 418233","access_levels":"public_access"},{"id":15590,"title":"Bakels Red Velvet Cake Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-red-velvet-cake-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"383771","access_levels":"public_access"},{"id":17100,"title":"Bakels Rhubarb & Apple Filling","url":"https:\/\/www.bakels.com.au\/products\/bakels-rhubarb-apple-filling\/","post_type":"Products","tax_terms":"Fruit & Fruit Flavoured Fillings","sku":"418842","access_levels":"public_access"},{"id":17837,"title":"Bakels Rich Dark Mud Cake Concentrate","url":"https:\/\/www.bakels.com.au\/products\/bakels-rich-dark-mud-cake-concentrate\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"383821","access_levels":"public_access"},{"id":15636,"title":"Bakels RTU Bun Glaze","url":"https:\/\/www.bakels.com.au\/products\/bakels-rtu-bun-glaze\/","post_type":"Products","tax_terms":"Glazes, Piping Gels & Dips","sku":"345954","access_levels":"public_access"},{"id":17509,"title":"Bakels RTU Fudge Icing - Cream Cheese","url":"https:\/\/www.bakels.com.au\/products\/bakels-rtu-fudge-icing-cream-cheese\/","post_type":"Products","tax_terms":"Icings & Icing Sugars","sku":"420752","access_levels":"public_access"},{"id":15679,"title":"Bakels Scone Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-scone-mix\/","post_type":"Products","tax_terms":"Various Pastry Cooking Products","sku":"376503","access_levels":"public_access"},{"id":18360,"title":"Bakels Senior","url":"https:\/\/www.bakels.com.au\/services\/baking-centres\/bakels-senior\/","post_type":"Baking Centres","access_levels":null},{"id":17937,"title":"Bakels Shortbread Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-shortbread-mix\/","post_type":"Products","tax_terms":"Cookie & Biscuit Mixes","sku":"382301","access_levels":"public_access"},{"id":17095,"title":"Bakels Slice Base Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-slice-base-mix\/","post_type":"Products","tax_terms":"Slice Mixes & Bases","sku":"562102","access_levels":"public_access"},{"id":17827,"title":"Bakels Soft Donut Concentrate","url":"https:\/\/www.bakels.com.au\/products\/bakels-soft-donut-concentrate\/","post_type":"Products","tax_terms":"Donut Mixes and Concentrates","sku":"376273","access_levels":"public_access"},{"id":15549,"title":"Bakels Sour Bread Concentrate","url":"https:\/\/www.bakels.com.au\/products\/bakels-sour-bread-concentrate\/","post_type":"Products","tax_terms":"Bread Mixes and Concentrates","sku":"394601","access_levels":"public_access"},{"id":17822,"title":"Bakels Spelt Bread Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-spelt-bread-mix\/","post_type":"Products","tax_terms":"Bread Mixes and Concentrates","sku":"394702","access_levels":"public_access"},{"id":17751,"title":"Bakels Sticky Date Cake Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-sticky-date-cake-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"381803","access_levels":"public_access"},{"id":17155,"title":"Bakels Strawberry Flavoured Mousse Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-strawberry-flavoured-mousse-mix\/","post_type":"Products","tax_terms":"Mousse Mixes","sku":"414752","access_levels":"public_access"},{"id":17048,"title":"Bakels Strawberry Flavoured Truffle MB","url":"https:\/\/www.bakels.com.au\/products\/bakels-strawberry-flavoured-truffle-mb\/","post_type":"Products","tax_terms":"Icings & Icing Sugars","sku":"514462","access_levels":"public_access"},{"id":15635,"title":"Bakels Super Glossy","url":"https:\/\/www.bakels.com.au\/products\/bakels-super-glossy\/","post_type":"Products","tax_terms":"Glazes, Piping Gels & Dips","sku":"345501","access_levels":"public_access"},{"id":16692,"title":"Bakels Tiger Paste Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-tiger-paste-mix\/","post_type":"Products","tax_terms":"Bread Toppings","sku":"196852","access_levels":"public_access"},{"id":17161,"title":"Bakels Tiramisu Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-tiramisu-mix\/","post_type":"Products","tax_terms":"Mousse Mixes","sku":"578002","access_levels":"public_access"},{"id":15699,"title":"Bakels Triple Choc Chunky Cookies","url":"https:\/\/www.bakels.com.au\/products\/bakels-triple-choc-chunky-cookies\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"632582","access_levels":"public_access"},{"id":17832,"title":"Bakels Utility Cake Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-utility-cake-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"382631","access_levels":"public_access"},{"id":15597,"title":"Bakels Vanilla Buttercream MB","url":"https:\/\/www.bakels.com.au\/products\/bakels-vanilla-buttercream-mb\/","post_type":"Products","tax_terms":"Icings & Icing Sugars","sku":"420653","access_levels":"public_access"},{"id":18037,"title":"Bakels Vanilla Patisserie Filling Mix NAFNAC","url":"https:\/\/www.bakels.com.au\/products\/bakels-vanilla-patisserie-filling-mix-nafnac\/","post_type":"Products","tax_terms":"Custard and Creme Mixes","sku":"336631","access_levels":null},{"id":3657,"title":"Bakels welcome students in partnership with The Worshipful Company of Bakers","url":"https:\/\/www.bakels.com.au\/bakels-welcome-students-in-partnership-with-the-worshipful-company-of-bakers\/","post_type":"Posts","tax_terms":"Events","access_levels":null},{"id":15695,"title":"Bakels White Chocolate & Macadamia Cookie (40g)","url":"https:\/\/www.bakels.com.au\/products\/bakels-white-chocolate-macadamia-cookie-40g\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"631982 (40g)","access_levels":"public_access"},{"id":17157,"title":"Bakels White Mousse Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-white-mousse-mix\/","post_type":"Products","tax_terms":"Mousse Mixes","sku":"414801, 414802, 414803","access_levels":"public_access"},{"id":15592,"title":"Bakels White Mud Cake Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-white-mud-cake-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"384661","access_levels":"public_access"},{"id":17054,"title":"Bakels White Truffle Firm MB","url":"https:\/\/www.bakels.com.au\/products\/bakels-white-truffle-firm-mb\/","post_type":"Products","tax_terms":"Icings & Icing Sugars","sku":"514412","access_levels":"public_access"},{"id":15632,"title":"Bakels White Truffle MB","url":"https:\/\/www.bakels.com.au\/products\/bakels-white-truffle-mb\/","post_type":"Products","tax_terms":"Fondants, Chocolate, Ganache & Truffles, Icings & Icing Sugars","sku":"514372","access_levels":"public_access"},{"id":28955,"title":"Bakels Wild Blueberry Filling 30%","url":"https:\/\/www.bakels.com.au\/products\/bakels-wild-blueberry-filling-30\/","post_type":"Products","tax_terms":"Fruit & Fruit Flavoured Fillings","sku":"418992","access_levels":"public_access"},{"id":18431,"title":"Bakels Wrappable Icing (White) NAFNAC","url":"https:\/\/www.bakels.com.au\/products\/bakels-wrappable-icing-white-nafnac\/","post_type":"Products","tax_terms":"Icings & Icing Sugars","sku":"426051","access_levels":null},{"id":15545,"title":"Bakels Yeast Raised Donut Mix","url":"https:\/\/www.bakels.com.au\/products\/bakels-yeast-raised-donut-mix\/","post_type":"Products","tax_terms":"Donut Mixes and Concentrates","sku":"376292","access_levels":"public_access"},{"id":15668,"title":"Bakels Yolk Yellow Colour","url":"https:\/\/www.bakels.com.au\/products\/bakels-yolk-yellow-colour\/","post_type":"Products","tax_terms":"Flavouring Pastes, Essences & Colours","sku":"461102","access_levels":"public_access"},{"id":29100,"title":"Baktem Red V","url":"https:\/\/www.bakels.com.au\/products\/baktem-red-v\/","post_type":"Products","tax_terms":"Specialised Fats","sku":"172021","access_levels":"public_access"},{"id":15513,"title":"Baktem Special V","url":"https:\/\/www.bakels.com.au\/products\/baktem-special-v\/","post_type":"Products","tax_terms":"Specialised Fats","sku":"171801","access_levels":"public_access"},{"id":15676,"title":"Balec","url":"https:\/\/www.bakels.com.au\/products\/balec\/","post_type":"Products","tax_terms":"Various Pastry Cooking Products","sku":"325001","access_levels":"public_access"},{"id":16889,"title":"Balec Solution (Using Balec)","url":"https:\/\/www.bakels.com.au\/recipes\/balec-solution-using-balec\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17387,"title":"Banana and Blueberry Bread (Using Bakels Banana Bread Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/banana-and-blueberry-bread-using-bakels-banana-bread-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17134,"title":"Banana and Pecan Cake (Using Bakels Homestyle Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/banana-and-pecan-cake-using-bakels-homestyle-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17386,"title":"Banana Bread (Using Bakels Banana Bread Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/banana-bread-using-bakels-banana-bread-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17436,"title":"Banana Cake (Using Bakels Banana Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/banana-cake-using-bakels-banana-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17434,"title":"Banana Cake (Using Bakels Carrot Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/banana-cake-using-bakels-carrot-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16895,"title":"Banana Cake (Using Bakels Vegan Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/banana-cake-using-bakels-vegan-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17139,"title":"Banana Cake Muffins (Using Bakels Creme Cake Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/banana-cake-muffins-using-bakels-creme-cake-muffin-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":16991,"title":"Banana Loaf (Using Bakels Homestyle Cake)","url":"https:\/\/www.bakels.com.au\/recipes\/banana-loaf-using-bakels-homestyle-cake\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16962,"title":"Banana Loaf (Using Pettina Fruit and Nut Loaf Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/banana-loaf-using-pettina-fruit-and-nut-loaf-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17394,"title":"Barossa Slice (Using Pettina Kokomix)","url":"https:\/\/www.bakels.com.au\/recipes\/barossa-slice-using-pettina-kokomix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16909,"title":"Basic Cake Muffins or Cup Cakes (Using Bakels All-In Buttacake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/basic-cake-muffins-or-cup-cakes-using-bakels-all-in-buttacake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15785,"title":"Basic Cake Recipe","url":"https:\/\/www.bakels.com.au\/recipes\/basic-cake-recipe\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16767,"title":"Basic Cake Recipe (Using Cake Margarine - Medium Grade)","url":"https:\/\/www.bakels.com.au\/recipes\/basic-cake-recipe-using-cake-margarine-medium-grade\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15731,"title":"Basic Mock Cream","url":"https:\/\/www.bakels.com.au\/recipes\/basic-mock-cream\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":17162,"title":"Basic Recipe for Block Cakes, Bars and Cupcakes (Using Apito Utility Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/basic-recipe-for-block-cakes-bars-and-cupcakes-using-apito-utility-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16765,"title":"Basic White Bread & Rolls (Using Materfat Supreme V)","url":"https:\/\/www.bakels.com.au\/recipes\/basic-white-bread-rolls-using-materfat-supreme-v\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":15718,"title":"Basic White Bread and Rolls (using Bakels Dobrim 500 Improver)","url":"https:\/\/www.bakels.com.au\/recipes\/basic-white-bread-and-rolls-using-bakels-dobrim-500-improver\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":15783,"title":"Basic White Bread and Rolls (using Bakels Extra 1% Improver)","url":"https:\/\/www.bakels.com.au\/recipes\/basic-white-bread-and-rolls-using-bakels-extra-1-improver\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":15708,"title":"Basic White Bread and Rolls (using Baktem Special V)","url":"https:\/\/www.bakels.com.au\/recipes\/basic-white-bread-and-rolls-using-baktem-special-v\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":15775,"title":"Basic White Bread and Rolls (Using Brittex 2000V)","url":"https:\/\/www.bakels.com.au\/recipes\/basic-white-bread-and-rolls-using-brittex-2000v\/","post_type":"Recipes","access_levels":null},{"id":15710,"title":"Basic White Bread and Rolls (using Eminex V)","url":"https:\/\/www.bakels.com.au\/recipes\/basic-white-bread-and-rolls-using-eminex-v\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":15782,"title":"Basic White Bread and Rolls (Using Quantum CL 1000 Improver)","url":"https:\/\/www.bakels.com.au\/recipes\/basic-white-bread-and-rolls-using-quantum-cl-1000-improver\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":16796,"title":"Basic White Bread and Rolls (Using Quantum Plus Improver)","url":"https:\/\/www.bakels.com.au\/recipes\/basic-white-bread-and-rolls-using-quantum-plus-improver\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":15707,"title":"Basic White Bread and Rolls (using Voltem)","url":"https:\/\/www.bakels.com.au\/recipes\/basic-white-bread-and-rolls-using-voltem\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":17371,"title":"Basic White Fancy Rolls (Using Bakels Advance Bread and Roll Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/basic-white-fancy-rolls-using-bakels-advance-bread-and-roll-concentrate\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15803,"title":"Batter Mix","url":"https:\/\/www.bakels.com.au\/recipes\/batter-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17152,"title":"Bavarian Supreme","url":"https:\/\/www.bakels.com.au\/products\/bavarian-supreme\/","post_type":"Products","tax_terms":"Custard and Creme Mixes","sku":"338002","access_levels":"public_access"},{"id":17214,"title":"Beef and Burgundy Pie Filling (Using Bakels Cook Up Starch)","url":"https:\/\/www.bakels.com.au\/recipes\/beef-and-burgundy-pie-filling-using-bakels-cook-up-starch\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":3393,"title":"Belgium","url":"https:\/\/www.bakels.com.au\/services\/baking-centres\/belgium\/","post_type":"Baking Centres","access_levels":null},{"id":17347,"title":"Biscuit Base (Using Bakels Biscuit Crumb Base)","url":"https:\/\/www.bakels.com.au\/recipes\/biscuit-base-using-bakels-biscuit-crumb-base\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17092,"title":"Biscuit Crumb Base MB","url":"https:\/\/www.bakels.com.au\/products\/biscuit-crumb-base-mb\/","post_type":"Products","tax_terms":"Slice Mixes & Bases","sku":"562002, 562004","access_levels":"public_access"},{"id":16884,"title":"Black and White Slice or Tarts (Using Actiwhite)","url":"https:\/\/www.bakels.com.au\/recipes\/black-and-white-slice-or-tarts-using-actiwhite\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16810,"title":"Blackberry or Loganberry Pie Filling (Using Bakels Instant Starch)","url":"https:\/\/www.bakels.com.au\/recipes\/blackberry-or-loganberry-pie-filling-using-bakels-instant-starch\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16897,"title":"Blueberry and Lemon Muffin (Using Bakels Vegan Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/blueberry-and-lemon-muffin-using-bakels-vegan-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17145,"title":"Blueberry Cake Muffins (Using Bakels All-In Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/blueberry-cake-muffins-using-bakels-all-in-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15786,"title":"Blueberry Cream Cheese Slice","url":"https:\/\/www.bakels.com.au\/recipes\/blueberry-cream-cheese-slice\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16893,"title":"Blueberry Cream Cheese Slice (Using Bakels Buttacake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/blueberry-cream-cheese-slice-using-bakels-buttacake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16886,"title":"Boiled Meringue (Using Actiwhite)","url":"https:\/\/www.bakels.com.au\/recipes\/boiled-meringue-using-actiwhite\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15720,"title":"Bread (using Advance 1000 Improver)","url":"https:\/\/www.bakels.com.au\/recipes\/bread-using-advance-1000-improver\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":15723,"title":"Bread (using Advance 500 Improver)","url":"https:\/\/www.bakels.com.au\/recipes\/bread-using-advance-500-improver\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":17367,"title":"Bread and Rolls (Using Bakels High Fibre Low GI Bread Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/bread-and-rolls-using-bakels-high-fibre-low-gi-bread-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17366,"title":"Bread and Rolls (Using Bakels Multiseed Bread Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/bread-and-rolls-using-bakels-multiseed-bread-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16834,"title":"Brioche (Using Brioche Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/brioche-using-brioche-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":16833,"title":"Brioche 10% (Using Brioche Concentrate Paste)","url":"https:\/\/www.bakels.com.au\/recipes\/brioche-10-using-brioche-concentrate-paste\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16832,"title":"Brioche 20% (Using Brioche Concentrate Paste)","url":"https:\/\/www.bakels.com.au\/recipes\/brioche-20-using-brioche-concentrate-paste\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17794,"title":"Brioche Concentrate Paste","url":"https:\/\/www.bakels.com.au\/products\/brioche-concentrate-paste\/","post_type":"Products","tax_terms":"Bread Mixes and Concentrates","sku":"378562","access_levels":"public_access"},{"id":3390,"title":"British Bakels","url":"https:\/\/www.bakels.com.au\/services\/baking-centres\/british-bakels\/","post_type":"Baking Centres","access_levels":null},{"id":15509,"title":"Brittex 2000 V","url":"https:\/\/www.bakels.com.au\/products\/brittex-2000-v\/","post_type":"Products","tax_terms":"Specialised Fats","sku":"111501","access_levels":"public_access"},{"id":15759,"title":"Brownies","url":"https:\/\/www.bakels.com.au\/recipes\/brownies\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17414,"title":"Buerli Rolls (Using Artisan 7% Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/buerli-rolls-using-artisan-7-concentrate\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16910,"title":"Buttacake (Using Bakels All-In Buttacake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/buttacake-using-bakels-all-in-buttacake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16915,"title":"Buttacake (Using Bakels Buttacake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/buttacake-using-bakels-buttacake-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17193,"title":"Butter Bars - Date Bars (Using Pettina Nut and Fruit Loaf Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/butter-bars-date-bars-using-pettina-nut-and-fruit-loaf-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17194,"title":"Butter Bars - Golden Apricot Bars (Using Pettina Fruit and Nut Loaf Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/butter-bars-golden-apricot-bars-using-pettina-fruit-and-nut-loaf-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":16908,"title":"Butter Bars - Golden Cherry Bars (Using Bakels Buttacake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/butter-bars-golden-cherry-bars-using-bakels-buttacake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16779,"title":"Butterscotch Filling (Using Cake Margarine - Medium Grade)","url":"https:\/\/www.bakels.com.au\/recipes\/butterscotch-filling-using-cake-margarine-medium-grade\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17215,"title":"Butterscotch Sauce (Using Bakels Cook Up Starch)","url":"https:\/\/www.bakels.com.au\/recipes\/butterscotch-sauce-using-bakels-cook-up-starch\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16831,"title":"Cake Donut - Century B & F Type Cutters (Using Bakels Cake Donut Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/cake-donut-century-b-f-type-cutters-using-bakels-cake-donut-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16817,"title":"Cake Donut - Hand Donut Dropper (Using Bakels Cake Donut Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/cake-donut-hand-donut-dropper-using-bakels-cake-donut-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16818,"title":"Cake Donuts - Automatic Donut Machine (Using Bakels Cake Donut Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/cake-donuts-automatic-donut-machine-using-bakels-cake-donut-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15572,"title":"Cake Margarine Medium","url":"https:\/\/www.bakels.com.au\/products\/cake-margarine-medium\/","post_type":"Products","tax_terms":"Sponge & Cake Emulsifiers- Cake- Margarines","sku":"166031","access_levels":"public_access"},{"id":17170,"title":"Cake Muffins and Cupcakes (Using Apito Utility Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/cake-muffins-and-cupcakes-using-apito-utility-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16916,"title":"Cake Muffins or Cup Cakes (Using Bakels Buttacake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/cake-muffins-or-cup-cakes-using-bakels-buttacake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15706,"title":"Canola Oil RBD","url":"https:\/\/www.bakels.com.au\/products\/canola-oil\/","post_type":"Products","tax_terms":"Fats & Oils","sku":"134607","access_levels":"public_access"},{"id":16927,"title":"Cappuccino Coffee Cups (Using Bakels Creme Cake Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/cappuccino-coffee-cups-using-bakels-creme-cake-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17324,"title":"Cappuccino Coffee Filling (Using Pettina Fond Suisse)","url":"https:\/\/www.bakels.com.au\/recipes\/cappuccino-coffee-filling-using-pettina-fond-suisse\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16926,"title":"Cappuccino Slice (Using Bakels Creme Cake Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/cappuccino-slice-using-bakels-creme-cake-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16918,"title":"Caramel and Nut Muffins or Cup Cakes (Using Bakels Buttacake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/caramel-and-nut-muffins-or-cup-cakes-using-bakels-buttacake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17172,"title":"Caramel and Nut Muffins or Cupcakes (Using Apito Utility Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/caramel-and-nut-muffins-or-cupcakes-using-apito-utility-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17842,"title":"Caramel Cr\u00e8me","url":"https:\/\/www.bakels.com.au\/products\/caramel-creme\/","post_type":"Products","tax_terms":"Caramel and Creme Fillings","sku":"414362","access_levels":"public_access"},{"id":17004,"title":"Caramel Flavoured Delite Cake (Using Bakels Caramel Delite Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/caramel-flavoured-delite-cake-using-bakels-caramel-delite-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15629,"title":"Caramel Flavoured Fondant","url":"https:\/\/www.bakels.com.au\/products\/caramel-soft-fondant\/","post_type":"Products","tax_terms":"Fondants, Chocolate, Ganache & Truffles","sku":"425613","access_levels":"public_access"},{"id":18519,"title":"Caramel Milk Flavoured Truffle MB","url":"https:\/\/www.bakels.com.au\/products\/caramel-milk-flavoured-truffle-mb\/","post_type":"Products","tax_terms":"Fondants, Chocolate, Ganache & Truffles","sku":"514702","access_levels":"public_access"},{"id":17133,"title":"Caramel Pudding (Using Bakels Caramel Delite Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/caramel-pudding-using-bakels-caramel-delite-cake-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17238,"title":"Carrot and Apple Slice (Using Pettina Kokomix)","url":"https:\/\/www.bakels.com.au\/recipes\/carrot-and-apple-slice-using-pettina-kokomix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16938,"title":"Carrot and Raisin Cake (Using Bakels Homestyle Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/carrot-and-raisin-cake-using-bakels-homestyle-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17003,"title":"Carrot and Zucchini Cake (Using Bakels Homestyle Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/carrot-and-zucchini-cake-using-bakels-homestyle-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17252,"title":"Carrot Cake (Using Bakels Gourmet Carrot Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/carrot-cake-using-bakels-gourmet-carrot-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16905,"title":"Carrot Cake (Using Bakels Vegan Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/carrot-cake-using-bakels-vegan-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17432,"title":"Carrot Slice and Carrot Cake (Using Bakels Carrot Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/carrot-slice-and-carrot-cake-using-bakels-carrot-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17236,"title":"Cheese and Tomato Pie Filling (Using Bakels Cook Up Starch)","url":"https:\/\/www.bakels.com.au\/recipes\/cheese-and-tomato-pie-filling-using-bakels-cook-up-starch\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17297,"title":"Cheese Custard Fruit Filling (Using Bakels Gourmet Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/cheese-custard-fruit-filling-using-bakels-gourmet-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17357,"title":"Cheese Custard Fruit Filling (Using Pettina Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/cheese-custard-fruit-filling-using-pettina-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15744,"title":"Cheesecake - Light Texture (Using Bakels Gourmet Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/cheesecake-light-texture-using-bakels-gourmet-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":17288,"title":"Cheesecake - Light Texture (Using Pettina Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/cheesecake-light-texture-using-pettina-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17291,"title":"Cheesecake (Using Bakels Gourmet Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/cheesecake-using-bakels-gourmet-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17381,"title":"Cheesecake (Using Pettina Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/cheesecake-using-pettina-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":"public_access"},{"id":17363,"title":"Cheesecake Slice (Using Bakels Gourmet Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/cheesecake-slice-using-bakels-gourmet-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17302,"title":"Cheesecake Slice (Using Pettina Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/cheesecake-slice-using-pettina-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":"public_access"},{"id":16951,"title":"Cherry 'N' Rum Brownie Slice (Using Bakels Mud Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/cherry-n-rum-brownie-slice-using-bakels-mud-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17241,"title":"Cherry Coconut Slice (Using Bakels Neutral Hedgehog Slice)","url":"https:\/\/www.bakels.com.au\/recipes\/cherry-coconut-slice-using-bakels-neutral-hedgehog-slice\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17160,"title":"Cherry Downunder Cake (Using Bakels Creme Cake Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/cherry-downunder-cake-using-bakels-creme-cake-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16912,"title":"Chewy Cookie (Using Bakels Multi Cookie Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chewy-cookie-using-bakels-multi-cookie-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17213,"title":"Chicken and Leek Pie Filling (Using Bakels Cook Up Starch)","url":"https:\/\/www.bakels.com.au\/recipes\/chicken-and-leek-pie-filling-using-bakels-cook-up-starch\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15737,"title":"Chicken Pie Filling","url":"https:\/\/www.bakels.com.au\/recipes\/chicken-pie-filling\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":28959,"title":"Chile","url":"https:\/\/www.bakels.com.au\/services\/baking-centres\/chile\/","post_type":"Baking Centres","access_levels":null},{"id":16966,"title":"Choc Cherry Suprise Muffins (Bakels Chocolate Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/choc-cherry-suprise-muffins-bakels-chocolate-muffin-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17143,"title":"Choc Chip Cake Muffins (Using Bakels All-In Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/choc-chip-cake-muffins-using-bakels-all-in-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17333,"title":"Choc Chip Cookie (Using Bakels Frozen Choc Chip Cookie)","url":"https:\/\/www.bakels.com.au\/recipes\/choc-chip-cookie-using-bakels-frozen-choc-chip-cookie\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17207,"title":"Choc Chip Hedgehog Slice - Bake\/No Bake (Using Bakels Chocolate Hedgehog Slice Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/choc-chip-hedgehog-slice-bake-no-bake-using-bakels-chocolate-hedgehog-slice-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16965,"title":"Choc Chip Macadamia Muffin (Bakels Chocolate Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/choc-chip-macadamia-muffin-bakels-chocolate-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":28867,"title":"Choc Loaded Cookie 40%","url":"https:\/\/www.bakels.com.au\/products\/choc-loaded-cookie-40\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"631632","access_levels":"public_access"},{"id":17409,"title":"Choc Mud Cake (Using Bakels All In Choc Mud Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/choc-mud-cake-using-bakels-all-in-choc-mud-cake-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17239,"title":"Choc Raisin 'N' Pecan Slice (Using Pettina Kokomix)","url":"https:\/\/www.bakels.com.au\/recipes\/choc-raisin-n-pecan-slice-using-pettina-kokomix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17129,"title":"Choc Rum 'N' Raisin Muffins (Bakels Chocolate Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/choc-rum-n-raisin-muffins-bakels-chocolate-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":18466,"title":"Choc Sponge Rounds and Swiss Rolls","url":"https:\/\/www.bakels.com.au\/recipes\/choc-sponge-rounds-and-swiss-rolls\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":17182,"title":"Chockex Dark MB","url":"https:\/\/www.bakels.com.au\/products\/chockex-dark-mb\/","post_type":"Products","tax_terms":"Fondants, Chocolate, Ganache & Truffles","sku":"514308","access_levels":"public_access"},{"id":15633,"title":"Chockex Supreme MB","url":"https:\/\/www.bakels.com.au\/products\/chockex-supreme-mb\/","post_type":"Products","tax_terms":"Fondants, Chocolate, Ganache & Truffles","sku":"514507, 514502","access_levels":"public_access"},{"id":15634,"title":"Chockex White MB","url":"https:\/\/www.bakels.com.au\/products\/chockex-white-mb\/","post_type":"Products","tax_terms":"Fondants, Chocolate, Ganache & Truffles","sku":"514892","access_levels":"public_access"},{"id":17445,"title":"Chocolate And Apricot Loaf (Using Artisan 7% Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-and-apricot-loaf-using-artisan-7-concentrate\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16906,"title":"Chocolate Brownie (Using Bakels Vegan Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-brownie-using-bakels-vegan-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16972,"title":"Chocolate Brownie Slice - Alternative Recipe (Using Bakels Mud Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-brownie-slice-alternative-recipe-using-bakels-mud-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16973,"title":"Chocolate Brownie Slice (Using Bakels Mud Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-brownie-slice-using-bakels-mud-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16907,"title":"Chocolate Cake (Using Bakels Lite Cake Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-cake-using-bakels-lite-cake-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16904,"title":"Chocolate Cake (Using Bakels Vegan Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-cake-using-bakels-vegan-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17137,"title":"Chocolate Cake (Using Pettina Chocolate Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-cake-using-pettina-chocolate-cake-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":15751,"title":"Chocolate Caramel Slice","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-caramel-slice\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16921,"title":"Chocolate Cinnamon Cake (Using Apito Utility Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-cinnamon-cake-using-apito-utility-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17136,"title":"Chocolate Cinnamon Cake (Using Pettina Chocolate Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-cinnamon-cake-using-pettina-chocolate-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17905,"title":"Chocolate Cookie","url":"https:\/\/www.bakels.com.au\/products\/chocolate-cookie\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"632604 (25g)","access_levels":"public_access"},{"id":17198,"title":"Chocolate Flakes Dark","url":"https:\/\/www.bakels.com.au\/products\/chocolate-flakes-dark\/","post_type":"Products","tax_terms":"Fondants, Chocolate, Ganache & Truffles","sku":"514742","access_levels":"public_access"},{"id":17195,"title":"Chocolate Flakes White","url":"https:\/\/www.bakels.com.au\/products\/chocolate-flakes-white\/","post_type":"Products","tax_terms":"Fondants, Chocolate, Ganache & Truffles","sku":"514722","access_levels":"public_access"},{"id":15627,"title":"Chocolate Flavoured Fondant MB","url":"https:\/\/www.bakels.com.au\/products\/chocolate-flavoured-fondant\/","post_type":"Products","tax_terms":"Fondants, Chocolate, Ganache & Truffles","sku":"425413","access_levels":"public_access"},{"id":15763,"title":"Chocolate Fudge Hedgehog Slice","url":"https:\/\/www.bakels.com.au\/recipes\/bakels-chocolate-hedgehog-slice-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17383,"title":"Chocolate Fudge Icing (Fondant White -Extra Soft)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-fudge-icing-fondant-white-extra-soft\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17375,"title":"Chocolate Fudge Icing (Using Bakels Fondant Standard- White)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-fudge-icing-using-bakels-fondant-standard-white\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17382,"title":"Chocolate Fudge Icing (Using Fondant White - Soft)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-fudge-icing-using-fondant-white-soft\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17360,"title":"Chocolate Jelly Cheesecake [J] (Using Bakels Gourmet Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-jelly-cheesecake-using-bakels-gourmet-cheesecake-mix-2\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17299,"title":"Chocolate Jelly Cheesecake [J] (Using Pettina Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-jelly-cheesecake-using-pettina-cheesecake-mix-2\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17361,"title":"Chocolate Jelly Cheesecake [K] (Using Bakels Gourmet Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-jelly-cheesecake-using-bakels-gourmet-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17352,"title":"Chocolate Jelly Cheesecake [K] (Using Pettina Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-jelly-cheesecake-using-pettina-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17132,"title":"Chocolate Lava Cake (Using Bakels Chocolate Lava Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-lava-cake-using-bakels-chocolate-lava-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17760,"title":"Chocolate Lava Cake Mix","url":"https:\/\/www.bakels.com.au\/products\/chocolate-lava-cake-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"383591","access_levels":"public_access"},{"id":17348,"title":"Chocolate Mousse (Using Bakels Choco Mousse Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-mousse-using-bakels-choco-mousse-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17319,"title":"Chocolate Mousse (Using Pettina Fond Suisse)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-mousse-using-pettina-fond-suisse\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17377,"title":"Chocolate Mousse and Cream (Using Bakels Choc Mousse Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-mousse-and-cream-using-bakels-choc-mousse-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17342,"title":"Chocolate Mousse and Whole Milk (Using Bakels Choco Mousse Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-mousse-and-whole-milk-using-bakels-choco-mousse-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16969,"title":"Chocolate Muffins (Using Bakels Chocolate Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-muffins-using-bakels-chocolate-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":"public_access"},{"id":16891,"title":"Chocolate Muffins or Cup Cakes (Using Bakels Buttacake MIx)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-muffins-or-cup-cakes-using-bakels-buttacake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16801,"title":"Chocolate Peanut Slice or Tarts (Using Actiwhite)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-peanut-slice-or-tarts-using-actiwhite\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16953,"title":"Chocolate Peppermint Slice (Using Bakels Mud Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-peppermint-slice-using-bakels-mud-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17474,"title":"Chocolate Rainbow Cookie","url":"https:\/\/www.bakels.com.au\/products\/chocolate-rainbow-cookie\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"660804","access_levels":"public_access"},{"id":17364,"title":"Chocolate Ripple Cheesecake (Using Bakels Gourmet Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-ripple-cheesecake-using-bakels-gourmet-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17358,"title":"Chocolate Ripple Cheesecake (Using Pettina Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-ripple-cheesecake-using-pettina-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17098,"title":"Chocolate Rum and Raisin Pudding (Using Bakels Chocolate Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-rum-and-raisin-pudding-using-bakels-chocolate-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17266,"title":"Chocolate Sponge - Alternative Recipe (Using Bakels Gluten Free Baking Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-sponge-alternative-recipe-using-bakels-gluten-free-baking-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17267,"title":"Chocolate Sponge (Using Bakels Gluten Free Baking Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-sponge-using-bakels-gluten-free-baking-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16979,"title":"Chocolate Sticky Date Cake (Using Bakels Homestyle Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-sticky-date-cake-using-bakels-homestyle-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17185,"title":"Chocolate Sticky Date Cake (Using Bakels Sticky Date Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-sticky-date-cake-using-bakels-sticky-date-cake-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":16957,"title":"Chocolate Torte (Using Bakels Chocolate Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-torte-using-bakels-chocolate-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16937,"title":"Chocolate Zucchini Cake (Using Homestyle Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/chocolate-zucchini-cake-using-homestyle-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15764,"title":"Christmas Hedgehog Slice","url":"https:\/\/www.bakels.com.au\/recipes\/christmas-hedgehog-slice\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16922,"title":"Christmas Pudding (Using Apito Utility Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/christmas-pudding-using-apito-utility-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16892,"title":"Christmas Pudding (Using Bakels Buttacake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/christmas-pudding-using-bakels-buttacake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17191,"title":"Christmas Pudding (Using Bakels Fruit Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/christmas-pudding-using-bakels-fruit-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16899,"title":"Christmas Pudding (Using Bakels Vegan Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/christmas-pudding-using-bakels-vegan-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16797,"title":"Christmas Pudding (Using Cake Margarine - Medium Grade)","url":"https:\/\/www.bakels.com.au\/recipes\/christmas-pudding-using-cake-margarine-medium-grade\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17256,"title":"Ciabatta (Using Bakels Ciabatta Bread Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/ciabatta-using-bakels-ciabatta-bread-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17455,"title":"Ciabatta\/Ciabattina (Using Artisan 7% Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/ciabatta-ciabattina-using-artisan-7-concentrate\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":18511,"title":"CL Soft","url":"https:\/\/www.bakels.com.au\/products\/cl-soft\/","post_type":"Products","tax_terms":"Bread Improvers","sku":"253511","access_levels":"public_access"},{"id":17201,"title":"Coconut Cream Slice (Using Pettina Kokomix)","url":"https:\/\/www.bakels.com.au\/recipes\/coconut-cream-slice-using-pettina-kokomix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17495,"title":"Coconut Drops","url":"https:\/\/www.bakels.com.au\/products\/coconut-drops\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"631052","access_levels":"public_access"},{"id":17410,"title":"Coconut Drops, Macaroons, Coconut Slice etc (Using Pettina Kokomix)","url":"https:\/\/www.bakels.com.au\/recipes\/coconut-drops-macaroons-coconut-slice-etc-using-pettina-kokomix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15805,"title":"Coconut Macaroons (Using Bakels Macaron Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/coconut-macaroons\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17395,"title":"Coconut Mix for Asian Bread (Using Pettina Kokomix)","url":"https:\/\/www.bakels.com.au\/recipes\/coconut-mix-for-asian-bread-using-pettina-kokomix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17206,"title":"Coconut Topping (Using Pettina Kokomix)","url":"https:\/\/www.bakels.com.au\/recipes\/coconut-topping-using-pettina-kokomix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":16950,"title":"Coffee 'N' Walnut Brownie Slice (Using Bakels Mud Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/coffee-n-walnut-brownie-slice-using-bakels-mud-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15794,"title":"Coffee and Walnut Slice","url":"https:\/\/www.bakels.com.au\/recipes\/coffee-and-walnut-slice\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":16782,"title":"Coffee Butterscotch Slice or Tarts (Using Actiwhite)","url":"https:\/\/www.bakels.com.au\/recipes\/coffee-butterscotch-slice-or-tarts-using-actiwhite\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17269,"title":"Coffee Cake (Using Bakels Gluten Free Baking Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/coffee-cake-using-bakels-gluten-free-baking-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17168,"title":"Coffee Cake (Using Bakels Lite Cake Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/coffee-cake-using-bakels-lite-cake-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17268,"title":"Coffee Walnut Cake (Using Bakels Gluten Free Baking Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/coffee-walnut-cake-using-bakels-gluten-free-baking-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16788,"title":"Cold Meringues (Using Actiwhite)","url":"https:\/\/www.bakels.com.au\/recipes\/cold-meringues-using-actiwhite\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17313,"title":"Continental Filling Cream (Using Pettina Fond Suisse)","url":"https:\/\/www.bakels.com.au\/recipes\/continental-filling-cream-using-pettina-fond-suisse\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15789,"title":"Continental Vanilla Custard","url":"https:\/\/www.bakels.com.au\/recipes\/continental-vanilla-custard\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16875,"title":"Continental Vanilla Custard (Using Bakels Instant Continental Custard Mix NAFNAC)","url":"https:\/\/www.bakels.com.au\/recipes\/continental-vanilla-custard-using-bakels-instant-continental-custard-mix-nafnac\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":"public_access"},{"id":17315,"title":"Continental Yogurt Filling (Using Pettina Fond Suisse)","url":"https:\/\/www.bakels.com.au\/recipes\/continental-yogurt-filling-using-pettina-fond-suisse\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16913,"title":"Cookies (Using Bakels Multi Cookie Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/cookies-using-bakels-multi-cookie-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17456,"title":"Cornflake Cookie","url":"https:\/\/www.bakels.com.au\/products\/cornflake-cookie\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"631756","access_levels":"public_access"},{"id":16799,"title":"Cornflake Slice (Using Actiwhite)","url":"https:\/\/www.bakels.com.au\/recipes\/cornflake-slice-using-actiwhite\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17437,"title":"Cornmeal Cookie (Using Bakels Gluten Free Baking Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/cornmeal-cookie-using-bakels-gluten-free-baking-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17980,"title":"Country Oven Artisan Concentrate","url":"https:\/\/www.bakels.com.au\/products\/country-oven-artisan-concentrate\/","post_type":"Products","tax_terms":"Bread Mixes and Concentrates","sku":"394661","access_levels":"public_access"},{"id":17995,"title":"Country Oven Baguette (Using Country Oven Artisan Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/country-oven-baguette-using-country-oven-artisan-concentrate\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":17997,"title":"Country Oven Batard (Using Country Oven Artisan Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/country-oven-batard-using-country-oven-artisan-concentrate\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":17996,"title":"Country Oven Ciabatta (Using Country Oven Artisan Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/country-oven-ciabatta-using-country-oven-artisan-concentrate\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":17978,"title":"Country Oven Digestive Bread Concentrate","url":"https:\/\/www.bakels.com.au\/products\/country-oven-digestive-bread-concentrate\/","post_type":"Products","tax_terms":"Bread Mixes and Concentrates","sku":"394631","access_levels":"public_access"},{"id":17982,"title":"Country Oven Low GI Grains & Seed Bread Concentrate","url":"https:\/\/www.bakels.com.au\/products\/country-oven-low-gi-grains-seed-bread-concentrate\/","post_type":"Products","tax_terms":"Bread Mixes and Concentrates","sku":"394612","access_levels":"public_access"},{"id":17986,"title":"Country Oven Low GI Hi Fibre Sourdough Bread Concentrate","url":"https:\/\/www.bakels.com.au\/products\/country-oven-low-gi-hi-fibre-sourdough-bread-concentrate\/","post_type":"Products","tax_terms":"Bread Mixes and Concentrates","sku":"394622","access_levels":"public_access"},{"id":17984,"title":"Country Oven Rye Bread Concentrate","url":"https:\/\/www.bakels.com.au\/products\/country-oven-rye-bread-concentrate\/","post_type":"Products","tax_terms":"Bread Mixes and Concentrates","sku":"394642","access_levels":"public_access"},{"id":17994,"title":"Country Oven Sourdough Bread and Rolls (Using Country Oven Artisan Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/country-oven-sourdough-bread-and-rolls-using-country-oven-artisan-concentrate\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":16805,"title":"Cream Cheese Icing (Using Bakels Cream Cheese Icing Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/cream-cheese-icing-using-bakels-cream-cheese-icing-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16792,"title":"Cream or Fruit Buns (Using Hamburger Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/cream-or-fruit-buns-using-hamburger-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16793,"title":"Cream or Fruit Buns (Using Merita V)","url":"https:\/\/www.bakels.com.au\/recipes\/cream-or-fruit-buns-using-merita-v\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15800,"title":"Cream Puffs and \u00c9clairs","url":"https:\/\/www.bakels.com.au\/recipes\/cream-puffs-and-eclairs\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15559,"title":"Creaming Shortening","url":"https:\/\/www.bakels.com.au\/products\/creaming-shortening\/","post_type":"Products","tax_terms":"Fats & Oils, Sponge & Cake Emulsifiers- Cake- Margarines","sku":"166231","access_levels":"public_access"},{"id":15560,"title":"Creme Shortening - Medium Grade","url":"https:\/\/www.bakels.com.au\/products\/creme-shortening-medium-grade\/","post_type":"Products","tax_terms":"Fats & Oils, Sponge & Cake Emulsifiers- Cake- Margarines","sku":"173401","access_levels":"public_access"},{"id":15778,"title":"Croissants","url":"https:\/\/www.bakels.com.au\/recipes\/croissants\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":"public_access"},{"id":17390,"title":"Crunchy Crumble Topping (Using Pettina Kokomix)","url":"https:\/\/www.bakels.com.au\/recipes\/crunchy-crumble-topping-using-pettina-kokomix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16928,"title":"Cup Cakes (Using Bakels Creme Cake Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/cup-cakes-using-bakels-creme-cake-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17216,"title":"Curried Chicken Pie Filling (Using Bakels Cook Up Starch)","url":"https:\/\/www.bakels.com.au\/recipes\/curried-chicken-pie-filling-using-bakels-cook-up-starch\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16812,"title":"Curry Meat Pie Filling (Using Bakels Cook Up Starch)","url":"https:\/\/www.bakels.com.au\/recipes\/curry-meat-pie-filling-using-bakels-cook-up-starch\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16877,"title":"Custard Filling (Using Bavarian Supreme)","url":"https:\/\/www.bakels.com.au\/recipes\/custard-filling-using-bavarian-supreme\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":"public_access"},{"id":15788,"title":"Custard Tart Filling","url":"https:\/\/www.bakels.com.au\/recipes\/custard-tart-filling\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16890,"title":"Custard Tart Filling (Using Bakels Custard Tart Mix NAFNAC)","url":"https:\/\/www.bakels.com.au\/recipes\/custard-tart-filling-using-bakels-custard-tart-mix-nafnac\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16800,"title":"Custard Tart Filling (Using Custard Tart Mix NAFNAC FT)","url":"https:\/\/www.bakels.com.au\/recipes\/custard-tart-filling-using-custard-tart-mix-nafnac-ft\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16840,"title":"Damper (Using Pettina Scone Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/damper-using-pettina-scone-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17264,"title":"Dark Rye Bread (Using Bakels Scandinavian Rye Bread Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/dark-rye-bread-using-bakels-scandinavian-rye-bread-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17389,"title":"Date 'N' Rum Kokomix Slice (Using Pettina Kokomix)","url":"https:\/\/www.bakels.com.au\/recipes\/date-n-rum-kokomix-slice-using-pettina-kokomix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16936,"title":"Date and Walnut Cake (Bakels Homestyle Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/date-and-walnut-cake-bakels-homestyle-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16961,"title":"Date Loaf (Using Pettina Fruit and Nut Loaf Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/date-loaf-using-pettina-fruit-and-nut-loaf-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17284,"title":"Dominion Pudding (Using Bakels Gluten Free Baking Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/dominion-pudding-using-bakels-gluten-free-baking-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":18445,"title":"Donut Glaze","url":"https:\/\/www.bakels.com.au\/recipes\/donut-glaze\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":15672,"title":"Dorothy Plus MB","url":"https:\/\/www.bakels.com.au\/products\/dorothy-plus-mb\/","post_type":"Products","tax_terms":"Preservatives","sku":"359631","access_levels":null},{"id":16975,"title":"Double Choc 'N' Rum Brownie Slice (Using Bakels Mud Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/double-choc-n-rum-brownie-slice-using-bakels-mud-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16974,"title":"Double Choc Brownie Slice (Using Bakels Mud Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/double-choc-brownie-slice-using-bakels-mud-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17406,"title":"Double Choc Muffin (Using Bakels Choc Muffin Mix Without Egg)","url":"https:\/\/www.bakels.com.au\/recipes\/double-choc-muffin-using-bakels-choc-muffin-mix-without-egg\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17453,"title":"Double Mutschli (Using Artisan 7% Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/double-mutschli-using-artisan-7-concentrate\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17398,"title":"Dutch Apple (Using Pettina Fruit and Nut Loaf Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/dutch-apple-using-pettina-fruit-and-nut-loaf-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17123,"title":"Dutch Apple Cake (Using Pettina Fruit and Nut Loaf Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/dutch-apple-cake-using-pettina-fruit-and-nut-loaf-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16888,"title":"Easter Bun Crosses (Using Pettina Choux Paste Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/easter-bun-crosses-using-pettina-choux-paste-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16829,"title":"Easter Bun Crosses (Using Pettina Scone Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/easter-bun-crosses-using-pettina-scone-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17248,"title":"Easter Hedgehog Slice (Using Bakels Neutral Hedgehog Slice Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/easter-hedgehog-slice-using-bakels-neutral-hedgehog-slice-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":3394,"title":"Ecuador","url":"https:\/\/www.bakels.com.au\/services\/baking-centres\/ecuador\/","post_type":"Baking Centres","access_levels":null},{"id":17019,"title":"Eggless Vanilla Cake Mix","url":"https:\/\/www.bakels.com.au\/products\/eggless-vanilla-cake-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"375231","access_levels":"public_access"},{"id":16857,"title":"Eggless Vanilla Cake Mix (Using Bakels Eggless Vanilla Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/eggless-vanilla-cake-mix-using-bakels-eggless-vanilla-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15519,"title":"Emilka","url":"https:\/\/www.bakels.com.au\/products\/emilka\/","post_type":"Products","tax_terms":"Various Pastry Cooking Products","sku":"365001","access_levels":"public_access"},{"id":15514,"title":"Eminex V","url":"https:\/\/www.bakels.com.au\/products\/eminex-v\/","post_type":"Products","tax_terms":"Specialised Fats","sku":"173001","access_levels":"public_access"},{"id":16686,"title":"Emulmax Liquid 750\/115","url":"https:\/\/www.bakels.com.au\/products\/emulmax-liquid-750-115\/","post_type":"Products","tax_terms":"Specialised Fats","sku":"178305","access_levels":"public_access"},{"id":15516,"title":"Emulmax Liquid 750\/200","url":"https:\/\/www.bakels.com.au\/products\/emulmax-liquid-750-200\/","post_type":"Products","tax_terms":"Specialised Fats","sku":"178104","access_levels":"public_access"},{"id":17402,"title":"European Muffins (Using Bakels European Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/european-muffins-using-bakels-european-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17421,"title":"Farmer's Bread (Using Artisan 7% Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/farmers-bread-using-artisan-7-concentrate\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17184,"title":"Festive Christmas Cake (Using Apito Utility Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/festive-christmas-cake-using-apito-utility-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16911,"title":"Festive Christmas Cake (Using Bakels Buttacake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/festive-christmas-cake-using-bakels-buttacake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17186,"title":"Festive Christmas Cake (Using Bakels Fruit Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/festive-christmas-cake-using-bakels-fruit-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17122,"title":"Fil-O-Fine Fruit Mince NAFNAC","url":"https:\/\/www.bakels.com.au\/products\/fil-o-fine-fruit-mince-nafnac\/","post_type":"Products","tax_terms":"Fruit & Fruit Flavoured Fillings","sku":"585004","access_levels":"public_access"},{"id":15680,"title":"Fino Batter Mix","url":"https:\/\/www.bakels.com.au\/products\/fino-batter-mix\/","post_type":"Products","tax_terms":"Various Pastry Cooking Products","sku":"729501","access_levels":"public_access"},{"id":17142,"title":"Fino Custard Powder","url":"https:\/\/www.bakels.com.au\/products\/fino-custard-powder\/","post_type":"Products","tax_terms":"Custard and Creme Mixes","sku":"333202","access_levels":"public_access"},{"id":15568,"title":"Fino Meat Pie Seasoning","url":"https:\/\/www.bakels.com.au\/products\/fino-meat-pie-seasoning\/","post_type":"Products","tax_terms":"Specialised Pie & Potato Products","sku":"731001","access_levels":"public_access"},{"id":17931,"title":"Fino Meat Thickening","url":"https:\/\/www.bakels.com.au\/products\/fino-meat-thickening\/","post_type":"Products","tax_terms":"Specialised Pie & Potato Products","sku":"731601","access_levels":"public_access"},{"id":15571,"title":"Fino Potato Pie Mash","url":"https:\/\/www.bakels.com.au\/products\/fino-potato-pie-mash\/","post_type":"Products","tax_terms":"Specialised Pie & Potato Products","sku":"784503","access_levels":"public_access"},{"id":15582,"title":"Fino Wheat & Gluten Free Flour","url":"https:\/\/www.bakels.com.au\/products\/bakels-gluten-free-and-fino-wheat-flour\/","post_type":"Products","tax_terms":"Gluten Free Products","sku":"393232","access_levels":"public_access"},{"id":15729,"title":"Flaky Pastry (using Pastry Gems - Hard Grade)","url":"https:\/\/www.bakels.com.au\/recipes\/flaky-pastry-using-pastry-gems-hard-grade\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15725,"title":"Flaky Pastry (using Pastry Gems - Medium Grade)","url":"https:\/\/www.bakels.com.au\/recipes\/flaky-pastry-using-pastry-gems-medium-grade\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16944,"title":"Flourless Almond Cake (Using Bakels Flourless Almond Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/flourless-almond-cake-using-bakels-flourless-almond-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":"public_access"},{"id":16971,"title":"Flourless Apple, Cinnamon and Almond Cake (Using Bakels Flourless Almond Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/flourless-apple-cinnamon-and-almond-cake-using-bakels-flourless-almond-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16954,"title":"Flourless Banana, Honey and Almond Cake (Using Bakels Flourless Almond Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/flourless-banana-honey-and-almond-cake-using-bakels-flourless-almond-cake-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":16956,"title":"Flourless Orange and Almond Cake (Using Bakels Flourless Almond Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/flourless-orange-and-almond-cake-using-bakels-flourless-almond-cake-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":16946,"title":"Flourless Orange and Chia Cake (Using Bakels Flourless Almond Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/flourless-orange-and-chia-cake-using-bakels-flourless-almond-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16955,"title":"Flourless Peach, Pear and Almond Cake (Using Bakels Flourless Almond Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/flourless-peach-pear-and-almond-cake-using-bakels-flourless-almond-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16947,"title":"Flourless Vanilla, Taragon and Mint Cake (Using Bakels Flourless Almond Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/flourless-vanilla-taragon-and-mint-cake-using-bakels-flourless-almond-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17415,"title":"Focaccia (Using Artisan 7% Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/focaccia-using-artisan-7-concentrate\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17259,"title":"Foccacia Bread and Rolls (Using Bakels Ciabatta Bread Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/foccacia-bread-and-rolls-using-bakels-ciabatta-bread-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15626,"title":"Fondant White - Soft","url":"https:\/\/www.bakels.com.au\/products\/soft-white-fondant\/","post_type":"Products","tax_terms":"Fondants, Chocolate, Ganache & Truffles","sku":"425113","access_levels":"public_access"},{"id":17176,"title":"Fondant White Standard","url":"https:\/\/www.bakels.com.au\/products\/fondant-white-standard\/","post_type":"Products","tax_terms":"Fondants, Chocolate, Ganache & Truffles","sku":"425013","access_levels":"public_access"},{"id":15692,"title":"Frozen Shortcrust Lids (Sweet) - Large (19cm)","url":"https:\/\/www.bakels.com.au\/products\/frozen-shortcrust-lids-sweet-large-19cm\/","post_type":"Products","tax_terms":"Frozen Pastry","sku":"622852","access_levels":"public_access"},{"id":15691,"title":"Frozen Shortcrust Shells (Sweet) - Large Shallow (19cm)","url":"https:\/\/www.bakels.com.au\/products\/frozen-shortcrust-shells-sweet-large-shallow-19cm\/","post_type":"Products","tax_terms":"Frozen Pastry","sku":"622803","access_levels":"public_access"},{"id":15687,"title":"Frozen Shortcrust Shells (Sweet) - Medium","url":"https:\/\/www.bakels.com.au\/products\/frozen-shortcrust-shells-sweet-medium\/","post_type":"Products","tax_terms":"Frozen Pastry","sku":"622203","access_levels":"public_access"},{"id":15689,"title":"Frozen Shortcrust Shells (Sweet) - Small Deep","url":"https:\/\/www.bakels.com.au\/products\/frozen-shortcrust-shells-sweet-small-deep\/","post_type":"Products","tax_terms":"Frozen Pastry","sku":"622402","access_levels":"public_access"},{"id":16963,"title":"Fruit and Nut Loaf - Alternative recipe (Using Pettina Fruit and Nut Loaf Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/fruit-and-nut-loaf-alternative-recipe-using-pettina-fruit-and-nut-loaf-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17128,"title":"Fruit and Nut Loaf (Using Pettina Fruit and Nut Loaf Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/fruit-and-nut-loaf-using-pettina-fruit-and-nut-loaf-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17413,"title":"Fruit Bread and Buns (Using Bakels Advance Bread and Roll Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/fruit-bread-and-buns-using-bakels-advance-bread-and-roll-concentrate\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16898,"title":"Fruit Cake (Using Vegan Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/fruit-cake-using-vegan-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15762,"title":"Fruit Snack Slice","url":"https:\/\/www.bakels.com.au\/recipes\/fruit-snack-slice\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":17374,"title":"Fudge Icing (Using Bakels Icing Stabiliser)","url":"https:\/\/www.bakels.com.au\/recipes\/fudge-icing-using-bakels-icing-stabiliser\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16789,"title":"Fudge Icing (Using Creme Shortening - Medium Grade)","url":"https:\/\/www.bakels.com.au\/recipes\/fudge-icing-using-creme-shortening-medium-grade\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":28885,"title":"Funfetti Cookie","url":"https:\/\/www.bakels.com.au\/products\/funfetti-cookie\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"644032","access_levels":"public_access"},{"id":17343,"title":"Ganache (Using Bakels Chockex Supreme)","url":"https:\/\/www.bakels.com.au\/recipes\/ganache-using-bakels-chockex-supreme\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":18544,"title":"Germany","url":"https:\/\/www.bakels.com.au\/services\/baking-centres\/germany\/","post_type":"Baking Centres","access_levels":null},{"id":17427,"title":"Ginger and Macadamia Slice (Using Neutral Hedgehog Slice)","url":"https:\/\/www.bakels.com.au\/recipes\/ginger-and-macadamia-slice-using-neutral-hedgehog-slice\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16949,"title":"Ginger Delight Brownie Slice (Using Bakels Mud Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/ginger-delight-brownie-slice-using-bakels-mud-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16881,"title":"Glaze for Danish Pastry (Using Apito Superglaze - Apricot)","url":"https:\/\/www.bakels.com.au\/recipes\/glaze-for-danish-pastry-using-apito-superglaze-apricot\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16882,"title":"Glaze for Danish Pastry (Using Apito Superglaze)","url":"https:\/\/www.bakels.com.au\/recipes\/glaze-for-danish-pastry\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16879,"title":"Glaze for Pastries and Fermented Goods (Using Super Glossy Natural)","url":"https:\/\/www.bakels.com.au\/recipes\/glaze-for-pastries-and-fermented-goods-using-super-glossy-natural\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16880,"title":"Glaze for Pastries and Fermented Goods (Using Super Glossy)","url":"https:\/\/www.bakels.com.au\/recipes\/glaze-for-pastries-and-fermented-goods-using-super-glossy\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17344,"title":"Glossy Chocolate Icing (Using Bakels Chockex Supreme)","url":"https:\/\/www.bakels.com.au\/recipes\/glossy-chocolate-icing-using-bakels-chockex-supreme\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17439,"title":"Gluten Free Afghans (Using Bakels Gluten Free Baking Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/gluten-free-afghans-using-bakels-gluten-free-baking-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15779,"title":"Gluten Free Artisan Bread","url":"https:\/\/www.bakels.com.au\/recipes\/gluten-free-artisan-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":16693,"title":"Gluten Free Baking Powder","url":"https:\/\/www.bakels.com.au\/products\/gluten-free-baking-powder\/","post_type":"Products","tax_terms":"Raising Agents, Gluten Free Products","sku":"297361","access_levels":"public_access"},{"id":29327,"title":"Gluten Free Banana Bread Mix","url":"https:\/\/www.bakels.com.au\/products\/gluten-free-banana-bread-mix\/","post_type":"Products","tax_terms":"Gluten Free Products, Sponge & Cake Premixes","sku":"386333","access_levels":"public_access"},{"id":17438,"title":"Gluten Free Banana Cake or Muffins (Using Bakels Gluten Free Baking Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/gluten-free-banana-cake-or-muffins-using-bakels-gluten-free-baking-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17449,"title":"Gluten Free Bread (Using Bakels Gluten Free Bread Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/gluten-free-bread-using-bakels-gluten-free-bread-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17440,"title":"Gluten Free Cake and Muffin Base Recipe (Using Bakels Gluten Free Baking Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/gluten-free-cake-and-muffin-base-recipe-using-bakels-gluten-free-baking-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17441,"title":"Gluten Free Carrot Cake and Muffin (Using Gluten Free Baking Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/gluten-free-carrot-cake-and-muffin-using-gluten-free-baking-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17442,"title":"Gluten Free Cheese Scones (Using Bakels Gluten Free Baking Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/gluten-free-cheese-scones-using-bakels-gluten-free-baking-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":29328,"title":"Gluten Free Chocolate Brownie Mix","url":"https:\/\/www.bakels.com.au\/products\/gluten-free-chocolate-brownie-mix\/","post_type":"Products","tax_terms":"Gluten Free Products, Slice Mixes & Bases","sku":"383493","access_levels":"public_access"},{"id":17272,"title":"Gluten Free Chocolate Cake or Muffins (Using Bakels Gluten Free Baking Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/gluten-free-chocolate-cake-or-muffins-using-bakels-gluten-free-baking-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17271,"title":"Gluten Free Chocolate Chip Cookies (Using Bakels Gluten Free Baking Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/gluten-free-chocolate-chip-cookies-using-bakels-gluten-free-baking-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17276,"title":"Gluten Free Citrus Duet Cookies (Using Bakels Gluten Free Baking Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/gluten-free-citrus-duet-cookies-using-bakels-gluten-free-baking-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17277,"title":"Gluten Free Gingerbread (Using Bakels Gluten Free Baking Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/gluten-free-gingerbread-using-bakels-gluten-free-baking-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17275,"title":"Gluten Free Lemon Loaf (Using Bakels Gluten Free Baking Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/gluten-free-lemon-loaf-using-bakels-gluten-free-baking-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":29516,"title":"Gluten Free Moist Chocolate Cake Mix","url":"https:\/\/www.bakels.com.au\/products\/gluten-free-moist-chocolate-cake-mix\/","post_type":"Products","tax_terms":"Gluten Free Products, Sponge & Cake Premixes","sku":"383843","access_levels":"public_access"},{"id":17278,"title":"Gluten Free Rock Cakes (Using Bakels Gluten Free Baking Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/gluten-free-rock-cakes-using-bakels-gluten-free-baking-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15746,"title":"Gluten Free- Foccacia and Pizza","url":"https:\/\/www.bakels.com.au\/recipes\/gluten-free-foccacia-and-pizza\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":15637,"title":"Hadeja Flan Gel Neutral","url":"https:\/\/www.bakels.com.au\/products\/hadeja-flan-gel-neutral\/","post_type":"Products","tax_terms":"Glazes, Piping Gels & Dips","sku":"346202, 346204","access_levels":"public_access"},{"id":17370,"title":"Hamburger and Hot Dog Rolls (Using Bakels Advance Bread and Roll Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/hamburger-and-hot-dog-rolls-using-bakels-advance-bread-and-roll-concentrate\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16790,"title":"Hamburger Buns and Soft Rolls (Using Hamburger Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/hamburger-buns-and-soft-rolls-using-hamburger-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16684,"title":"Hamburger Mix","url":"https:\/\/www.bakels.com.au\/products\/hamburger-mix\/","post_type":"Products","tax_terms":"Bread Mixes and Concentrates, Specialised Fats","sku":"175001","access_levels":"public_access"},{"id":15673,"title":"Hercules Baking Powder","url":"https:\/\/www.bakels.com.au\/products\/hercules-baking-powder\/","post_type":"Products","tax_terms":"Raising Agents","sku":"297001","access_levels":"public_access"},{"id":15675,"title":"Hercules N Baking Powder","url":"https:\/\/www.bakels.com.au\/products\/hercules-n-baking-powder\/","post_type":"Products","tax_terms":"Raising Agents","sku":"297501","access_levels":"public_access"},{"id":16786,"title":"High Ratio Cake (Using Ovalett)","url":"https:\/\/www.bakels.com.au\/recipes\/high-ratio-cake-using-ovalett\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17171,"title":"Honey and Walnut Muffins and Cupcakes (Using Apito Utility Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/honey-and-walnut-muffins-and-cupcakes-using-apito-utility-cake-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":16917,"title":"Honey and Walnut Muffins or Cup Cakes (Using Bakels Buttacake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/honey-and-walnut-muffins-or-cup-cakes-using-bakels-buttacake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17192,"title":"Honey Bran Muffins (Using Pettina Fruit and Nut Loaf Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/honey-bran-muffins-using-pettina-fruit-and-nut-loaf-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17208,"title":"Honey Nut Slice (Using Neutral Hedgehog Slice)","url":"https:\/\/www.bakels.com.au\/recipes\/honey-nut-slice-using-neutral-hedgehog-slice\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17412,"title":"Honey Pecan Drops\/Slice (Using Pettina Kokomix)","url":"https:\/\/www.bakels.com.au\/recipes\/honey-pecan-drops-slice-using-pettina-kokomix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":18316,"title":"Hong Kong","url":"https:\/\/www.bakels.com.au\/services\/baking-centres\/hong-kong\/","post_type":"Baking Centres","access_levels":null},{"id":16776,"title":"Hot Cross Buns (Using Baktem Red V)","url":"https:\/\/www.bakels.com.au\/recipes\/hot-cross-buns-using-baktem-red-v\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":16791,"title":"Hot Cross Buns (Using Hamburger Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/hot-cross-buns-using-hamburger-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16794,"title":"Hot Cross Buns (Using Merita V)","url":"https:\/\/www.bakels.com.au\/recipes\/hot-cross-buns-using-merita-v\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":18293,"title":"India","url":"https:\/\/www.bakels.com.au\/services\/baking-centres\/india\/","post_type":"Baking Centres","access_levels":null},{"id":17258,"title":"Instant Ciabatta Bread (Using Bakels Ciabatta Bread Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/instant-ciabatta-bread-using-bakels-ciabatta-bread-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17253,"title":"Instant Focaccia Bread (Using Bakels Ciabatta Bread Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/instant-focaccia-bread-using-bakels-ciabatta-bread-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":16873,"title":"Italian Meat Pie Filling (Using Bakels Cook Up Starch)","url":"https:\/\/www.bakels.com.au\/recipes\/italian-meat-pie-filling-using-bakels-cook-up-starch\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16948,"title":"Jaffa Brownie Slice (Using Bakels Mud Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/jaffa-brownie-slice-using-bakels-mud-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16923,"title":"Jaffa Cake Muffins (Using Bakels Creme Cake Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/jaffa-cake-muffins-using-bakels-creme-cake-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17237,"title":"Jaffa Kokomix Slice (Using Pettina Kokomix)","url":"https:\/\/www.bakels.com.au\/recipes\/jaffa-kokomix-slice-using-pettina-kokomix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17428,"title":"Jaffa Slice (Using Neutral Hedgehog Slice Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/jaffa-slice-using-neutral-hedgehog-slice-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15741,"title":"Jam Roll","url":"https:\/\/www.bakels.com.au\/recipes\/jam-roll\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16806,"title":"Jelly for Fruit Flans (Using Hadeja Flan Gel - Apricot)","url":"https:\/\/www.bakels.com.au\/recipes\/jelly-for-fruit-flans-using-hadeja-flan-gel-apricot\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16705,"title":"Jelly for Fruit Flans (Using Hadeja Flan Gel - Neutral)","url":"https:\/\/www.bakels.com.au\/recipes\/jelly-for-fruit-flans\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17150,"title":"Kramess Vanilla Slice Mix","url":"https:\/\/www.bakels.com.au\/products\/kramess-vanilla-slice-mix\/","post_type":"Products","tax_terms":"Custard and Creme Mixes","sku":"337001","access_levels":"public_access"},{"id":15576,"title":"Labwhip","url":"https:\/\/www.bakels.com.au\/products\/labwhip\/","post_type":"Products","tax_terms":"Sponge & Cake Emulsifiers- Cake- Margarines","sku":"211601","access_levels":null},{"id":16371,"title":"Lamington Dip","url":"https:\/\/www.bakels.com.au\/recipes\/lamington-dip\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":16894,"title":"Lemon and Poppy Seed Bundt Cake (Using Bakels Vegan Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/lemon-and-poppy-seed-bundt-cake-using-bakels-vegan-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17350,"title":"Lemon Bavarian (Using Bakels Lemon Flavouring Filling)","url":"https:\/\/www.bakels.com.au\/recipes\/lemon-bavarian-using-bakels-lemon-flavouring-filling\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16878,"title":"Lemon Bavarian (Using Bavarian Supreme)","url":"https:\/\/www.bakels.com.au\/recipes\/lemon-bavarian-using-bavarian-supreme\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17287,"title":"Lemon Cheesecake Topping (Using Bakels Pettina Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/lemon-cheesecake-topping-using-bakels-pettina-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17309,"title":"Lemon Cheesecake Topping (Using Gourmet Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/lemon-cheesecake-topping-using-gourmet-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17189,"title":"Light Fruit Cake (Using Bakels Light Fruit Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/light-fruit-cake-using-bakels-light-fruit-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17260,"title":"Light Rye Bread (Using Bakels American Rye Bread Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/light-rye-bread-using-bakels-american-rye-bread-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16920,"title":"Lite Cake Muffins (Using Bakels Lite Cake Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/lite-cake-muffins-using-bakels-lite-cake-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16992,"title":"Lumberjack Cake (Using Bakels Homestyle Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/lumberjack-cake-using-bakels-homestyle-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17240,"title":"M&M Hedgehog Slice (Using Bakels Neutral Hedgehog Slice)","url":"https:\/\/www.bakels.com.au\/recipes\/mm-hedgehog-slice-using-bakels-neutral-hedgehog-slice\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16976,"title":"Macadamia and Ginger Cake (Using Bakels Homestyle Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/macadamia-and-ginger-cake-using-bakels-homestyle-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16772,"title":"Macadamia Crunch Topping (Using Cake Margarine - Medium Grade)","url":"https:\/\/www.bakels.com.au\/recipes\/macadamia-crunch-topping-using-cake-margarine-medium-grade\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17499,"title":"Macadamia Shortbread","url":"https:\/\/www.bakels.com.au\/products\/macadamia-shortbread\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"632405","access_levels":"public_access"},{"id":16798,"title":"Macarons (Using Bakels Macaron Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/macarons-using-bakels-macaron-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16785,"title":"Macaroon Slice or Tarts (Using Actiwhite)","url":"https:\/\/www.bakels.com.au\/recipes\/macaroon-slice-or-tarts-using-actiwhite\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":18203,"title":"Mainland China","url":"https:\/\/www.bakels.com.au\/services\/baking-centres\/mainland-china\/","post_type":"Baking Centres","access_levels":null},{"id":18270,"title":"Malaysia","url":"https:\/\/www.bakels.com.au\/services\/baking-centres\/malaysia\/","post_type":"Baking Centres","access_levels":null},{"id":15678,"title":"Mallowhip","url":"https:\/\/www.bakels.com.au\/products\/bakels-mallowhip\/","post_type":"Products","tax_terms":"Meringue and Mallow Mixes","sku":"343002","access_levels":"public_access"},{"id":16870,"title":"Marble Cake (Using Bakels Lite Cake Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/marble-cake-using-bakels-lite-cake-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16967,"title":"Marble Muffins (Using Bakels Chocolate Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/marble-muffins-using-bakels-chocolate-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17148,"title":"Marble Muffins (Using Bakels Creme Cake Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/marble-muffins-using-bakels-creme-cake-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17392,"title":"Marbled Choc Plain Slice (Using Pettina Kokomix)","url":"https:\/\/www.bakels.com.au\/recipes\/marbled-choc-plain-slice-using-pettina-kokomix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":15739,"title":"Mashed Potato for Pies","url":"https:\/\/www.bakels.com.au\/recipes\/mashed-potato-for-pies\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16683,"title":"Masterfat Supreme V","url":"https:\/\/www.bakels.com.au\/products\/masterfat-supreme-v\/","post_type":"Products","tax_terms":"Specialised Fats","sku":"112101","access_levels":"public_access"},{"id":15780,"title":"Meat Pie Filling","url":"https:\/\/www.bakels.com.au\/recipes\/meat-pie-filling\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":17316,"title":"Meat Pie Filling (Using Bakels Meat Pie Mix Complete)","url":"https:\/\/www.bakels.com.au\/recipes\/meat-pie-filling-using-bakels-meat-pie-mix-complete\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17317,"title":"Meat Pie Filling (Using Fino Meat Thickening)","url":"https:\/\/www.bakels.com.au\/recipes\/meat-pie-filling-using-fino-meat-thickening\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17281,"title":"Melting Moments (Using Bakels Gluten Free Baking Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/melting-moments-using-bakels-gluten-free-baking-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16783,"title":"Meringue Topping (Using Actiwhite)","url":"https:\/\/www.bakels.com.au\/recipes\/meringue-topping-using-actiwhite\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15515,"title":"Merita V MB","url":"https:\/\/www.bakels.com.au\/products\/merita-v-mb\/","post_type":"Products","tax_terms":"Specialised Fats","sku":"177501","access_levels":"public_access"},{"id":16874,"title":"Mexican (Chilli) Pie Filling (Using Bakels Cook Up Starch)","url":"https:\/\/www.bakels.com.au\/recipes\/mexican-chilli-pie-filling-using-bakels-cook-up-starch\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15753,"title":"Millionaires Mud Cake","url":"https:\/\/www.bakels.com.au\/recipes\/millionaires-mud-cake\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":16942,"title":"Mississippi Mud Cake (Using Bakels Mud Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/mississippi-mud-cake-using-bakels-mud-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16968,"title":"Mississippi Mud Christmas Pudding (Using Bakels Chocolate Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/mississippi-mud-christmas-pudding-using-bakels-chocolate-muffin-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":16959,"title":"Mocha Pecan Muffins (Using Bakels Chocolate Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/mocha-pecan-muffins-using-bakels-chocolate-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15524,"title":"Monofresh","url":"https:\/\/www.bakels.com.au\/products\/monofresh\/","post_type":"Products","tax_terms":"Bread Improvers","sku":"218604","access_levels":"public_access"},{"id":15798,"title":"Mud Cake","url":"https:\/\/www.bakels.com.au\/recipes\/mud-cake\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":16903,"title":"Mud Cake (Using Bakels Vegan Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/mud-cake-using-bakels-vegan-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16995,"title":"Mud Cake Mix","url":"https:\/\/www.bakels.com.au\/products\/mud-cake-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"383507, 383508","access_levels":"public_access"},{"id":16925,"title":"Muffins (Using Bakels All-In Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/muffins-using-bakels-all-in-muffin-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17408,"title":"Muffins (Using Pettina All In Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/muffins-using-pettina-all-in-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":28856,"title":"Multi Cookie Mix","url":"https:\/\/www.bakels.com.au\/products\/multi-cookie-mix\/","post_type":"Products","tax_terms":"Cookie & Biscuit Mixes","sku":"379901","access_levels":"public_access"},{"id":16930,"title":"Multi Fibre Cookies (Using Bakels Multi-Fibre Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/multi-fibre-cookies-using-bakels-multi-fibre-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16931,"title":"Multi Firbe Muffins (Using Multi-Fibre Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/multi-firbe-muffins-using-multi-fibre-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":3124,"title":"Multiseed Bread","url":"https:\/\/www.bakels.com.au\/recipes\/multiseed-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":17308,"title":"Neopolitan Slice\/Torte Cheesecake (Using Bakels Gourmet Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/neopolitan-slice-torte-cheesecake-using-gourmet-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17305,"title":"Neopolitan Slice\/Torte Cheesecake (Using Pettina Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/neopolitan-slice-torte-cheesecake-using-pettina-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17210,"title":"Neutral Hedgehog Slice (Using Bakels Neutral Hedgehog Slice Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/neutral-hedgehog-slice-using-bakels-neutral-hedgehog-slice-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17362,"title":"Nougat Slice\/Torte Cheesecake (Using Bakels Gourmet Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/nougat-slice-torte-cheesecake-using-bakels-gourmet-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17303,"title":"Nougat Slice\/Torte Cheesecake (Using Pettina Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/nougat-slice-torte-cheesecake-using-pettina-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16943,"title":"Nutty Oat Topping (Using Bakels Homestyle Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/nutty-oat-topping-using-bakels-homestyle-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16766,"title":"Nutty Oat Topping (Using Cake Margarine - Medium Grade)","url":"https:\/\/www.bakels.com.au\/recipes\/nutty-oat-topping-using-cake-margarine-medium-grade\/","post_type":"Recipes","access_levels":null},{"id":28864,"title":"Oat & Raisin Cookie (28g)","url":"https:\/\/www.bakels.com.au\/products\/oat-raisin-cookie-28g\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"631412","access_levels":"public_access"},{"id":28861,"title":"Oat & Raisin Cookie (50g)","url":"https:\/\/www.bakels.com.au\/products\/oat-raisin-cookie-50g\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"631412","access_levels":"public_access"},{"id":17431,"title":"Orange and Citrus Slice (Using Bakels Neutral Hedgehog Slice Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/orange-and-citrus-slice-using-bakels-neutral-hedgehog-slice-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15755,"title":"Orange and Poppyseed Muffins","url":"https:\/\/www.bakels.com.au\/recipes\/orange-and-poppyseed-muffins\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":17246,"title":"Orange and Poppyseed Slice (Using Bakels Neutral Hedgehog Slice Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/orange-and-poppyseed-slice-using-bakels-neutral-hedgehog-slice-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17169,"title":"Orange Cake (Using Bakels Lite Cake Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/orange-cake-using-bakels-lite-cake-muffin-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17378,"title":"Orange Syrup (Using Apito Flavouring Paste - Orange)","url":"https:\/\/www.bakels.com.au\/recipes\/orange-syrup-using-apito-flavouring-paste-orange\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15575,"title":"Ovalett","url":"https:\/\/www.bakels.com.au\/products\/ovalett\/","post_type":"Products","tax_terms":"Sponge & Cake Emulsifiers- Cake- Margarines","sku":"211002, 211003","access_levels":"public_access"},{"id":16828,"title":"Pancakes or Pikelets (Using Pettina Scone Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/pancakes-or-pikelets-using-pettina-scone-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17448,"title":"Pane Maggia 100% (Using Bakels Pane Maggia 100%)","url":"https:\/\/www.bakels.com.au\/recipes\/pane-maggia-100-using-bakels-pane-maggia-100\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17446,"title":"Panini (Using Artisan 7% Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/panini-using-artisan-7-concentrate\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17249,"title":"Panini Bread Rolls - Soft (Using Bakels Ciabatta Bread Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/panini-bread-rolls-soft-using-bakels-ciabatta-bread-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17335,"title":"Pastie Filling (Using Fino Meat Pie Seasoning)","url":"https:\/\/www.bakels.com.au\/recipes\/pastie-filling-using-fino-meat-pie-seasoning\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15552,"title":"Pastry Gems - (Medium Grade)","url":"https:\/\/www.bakels.com.au\/products\/pastry-gems-medium-grade\/","post_type":"Products","tax_terms":"Pastry Margarines","sku":"166011","access_levels":"public_access"},{"id":15557,"title":"Pastry Gems (Hard Grade)","url":"https:\/\/www.bakels.com.au\/products\/pastry-gems-hard-grade\/","post_type":"Products","tax_terms":"Pastry Margarines","sku":"166111","access_levels":"public_access"},{"id":15804,"title":"Pavlova","url":"https:\/\/www.bakels.com.au\/recipes\/pavlova\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":17228,"title":"Pea and Meat Pie Filling (Using Bakels Cook Up Starch)","url":"https:\/\/www.bakels.com.au\/recipes\/pea-and-meat-pie-filling-using-bakels-cook-up-starch\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17385,"title":"Pear and Raspberry Bread (Using Bakels Banana Bread Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/pear-and-raspberry-bread-using-bakels-banana-bread-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17120,"title":"Pettina Apple and Blueberry Mix","url":"https:\/\/www.bakels.com.au\/products\/pettina-apple-and-blueberry-mix\/","post_type":"Products","tax_terms":"Fruit & Fruit Flavoured Fillings","sku":"583002","access_levels":"public_access"},{"id":15623,"title":"Pettina Cheesecake Mix","url":"https:\/\/www.bakels.com.au\/products\/pettina-cheesecake-mix\/","post_type":"Products","tax_terms":"Cheesecake Mixes","sku":"579003","access_levels":"public_access"},{"id":17763,"title":"Pettina Chocolate Cake Mix","url":"https:\/\/www.bakels.com.au\/products\/pettina-chocolate-cake-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"383001","access_levels":"public_access"},{"id":15664,"title":"Pettina Chocolate Flavoured Paste","url":"https:\/\/www.bakels.com.au\/products\/pettina-chocolate-flavoured-paste\/","post_type":"Products","tax_terms":"Flavouring Pastes, Essences & Colours","sku":"438502","access_levels":"public_access"},{"id":15677,"title":"Pettina Choux Paste Mix","url":"https:\/\/www.bakels.com.au\/products\/pettina-choux-paste-mix\/","post_type":"Products","tax_terms":"Various Pastry Cooking Products","sku":"329001","access_levels":"public_access"},{"id":15593,"title":"Pettina Cream Stabiliser","url":"https:\/\/www.bakels.com.au\/products\/pettina-cream-stabiliser\/","post_type":"Products","tax_terms":"Custard and Creme Mixes","sku":"414003","access_levels":"public_access"},{"id":15624,"title":"Pettina Fond Suisse","url":"https:\/\/www.bakels.com.au\/products\/pettina-fond-suisse\/","post_type":"Products","tax_terms":"Mousse Mixes","sku":"761002","access_levels":"public_access"},{"id":17073,"title":"Pettina Fruit and Nut Loaf Mix","url":"https:\/\/www.bakels.com.au\/products\/pettina-fruit-and-nut-loaf-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"384001","access_levels":"public_access"},{"id":15601,"title":"Pettina Kokomix","url":"https:\/\/www.bakels.com.au\/products\/bakels-pettina-kokomix\/","post_type":"Products","tax_terms":"Slice Mixes & Bases","sku":"385002","access_levels":"public_access"},{"id":15641,"title":"Pettina Lamington Dip","url":"https:\/\/www.bakels.com.au\/products\/pettina-lamington-dip\/","post_type":"Products","tax_terms":"Glazes, Piping Gels & Dips","sku":"423001","access_levels":"public_access"},{"id":15683,"title":"Pettina Pavlova Mix","url":"https:\/\/www.bakels.com.au\/products\/pettina-pavlova-mix\/","post_type":"Products","tax_terms":"Meringue and Mallow Mixes","sku":"317003","access_levels":"public_access"},{"id":15642,"title":"Pettina Raspberry Dip","url":"https:\/\/www.bakels.com.au\/products\/pettina-raspberry-dip\/","post_type":"Products","tax_terms":"Glazes, Piping Gels & Dips","sku":"423504","access_levels":"public_access"},{"id":15661,"title":"Pettinice Dusting Sugar MB","url":"https:\/\/www.bakels.com.au\/products\/pettinice-dusting-sugar\/","post_type":"Products","tax_terms":"Icings & Icing Sugars","sku":"424002, 424003","access_levels":"public_access"},{"id":17702,"title":"Pettinice RTR Icing - Black","url":"https:\/\/www.bakels.com.au\/products\/pettinice-rtr-icing-black\/","post_type":"Products","tax_terms":"Icings & Icing Sugars","sku":"422012","access_levels":"public_access"},{"id":17726,"title":"Pettinice RTR Icing - Blue","url":"https:\/\/www.bakels.com.au\/products\/pettinice-rtr-icing-blue\/","post_type":"Products","tax_terms":"Icings & Icing Sugars","sku":"422072","access_levels":"public_access"},{"id":17746,"title":"Pettinice RTR Icing - Chocolate","url":"https:\/\/www.bakels.com.au\/products\/pettinice-rtr-icing-chocolate\/","post_type":"Products","tax_terms":"Icings & Icing Sugars","sku":"422303","access_levels":"public_access"},{"id":17716,"title":"Pettinice RTR Icing - Green","url":"https:\/\/www.bakels.com.au\/products\/pettinice-rtr-icing-green\/","post_type":"Products","tax_terms":"Icings & Icing Sugars","sku":"422042","access_levels":"public_access"},{"id":17729,"title":"Pettinice RTR Icing - Orange","url":"https:\/\/www.bakels.com.au\/products\/pettinice-rtr-icing-orange\/","post_type":"Products","tax_terms":"Icings & Icing Sugars","sku":"422082","access_levels":"public_access"},{"id":17709,"title":"Pettinice RTR Icing - Red","url":"https:\/\/www.bakels.com.au\/products\/pettinice-rtr-icing-red\/","post_type":"Products","sku":"422022","access_levels":"public_access"},{"id":17723,"title":"Pettinice RTR Icing - Yellow","url":"https:\/\/www.bakels.com.au\/products\/pettinice-rtr-icing-yellow\/","post_type":"Products","tax_terms":"Icings & Icing Sugars","sku":"422062","access_levels":"public_access"},{"id":17700,"title":"Pettinice RTR Icing MB - White","url":"https:\/\/www.bakels.com.au\/products\/pettinice-rtr-icing-mb-white\/","post_type":"Products","tax_terms":"Icings & Icing Sugars","sku":"422003, 422005","access_levels":"public_access"},{"id":17735,"title":"Pettinice RTR Pink Icing","url":"https:\/\/www.bakels.com.au\/products\/pettinice-rtr-pink-icing\/","post_type":"Products","tax_terms":"Icings & Icing Sugars","sku":"422112","access_levels":"public_access"},{"id":15561,"title":"Pie Base Concentrate","url":"https:\/\/www.bakels.com.au\/products\/pie-base-concentrate\/","post_type":"Products","tax_terms":"Specialised Fats, Specialised Pie & Potato Products","sku":"163001","access_levels":"public_access"},{"id":15563,"title":"Pie Bottom Fat V","url":"https:\/\/www.bakels.com.au\/products\/pie-bottom-fat-v\/","post_type":"Products","tax_terms":"Specialised Fats, Specialised Pie & Potato Products","sku":"173501","access_levels":"public_access"},{"id":15732,"title":"Pie Bottoms (Using Pie Base Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/pie-bottoms\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15734,"title":"Pie Bottoms (Using Pie Bottom Fat V)","url":"https:\/\/www.bakels.com.au\/recipes\/pie-bottoms-using-pie-bottom-fat-v\/","post_type":"Recipes","access_levels":null},{"id":16808,"title":"Pineapple Pie Filling (Using Instant Starch)","url":"https:\/\/www.bakels.com.au\/recipes\/pineapple-pie-filling-using-instant-starch\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16977,"title":"Pineapple Sour Cream Squares (Using Bakels Homestyle Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/pineapple-sour-cream-squares-using-bakels-homestyle-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15640,"title":"Piping Gel Neutral","url":"https:\/\/www.bakels.com.au\/products\/bakels-piping-gel-neutral\/","post_type":"Products","tax_terms":"Glazes, Piping Gels & Dips","sku":"347072","access_levels":"public_access"},{"id":16945,"title":"Pistachio\/Lime and Pomegranate Cake (Using Bakels Flourless Almond Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/pistachio-lime-and-pomegranate-cake-using-bakels-flourless-almond-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17255,"title":"Pizza Bases (Using Bakels Ciabatta Bread Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/pizza-bases-using-bakels-ciabatta-bread-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17407,"title":"Plain Muffin (Using Bakels Plain Muffin Mix No Egg)","url":"https:\/\/www.bakels.com.au\/recipes\/plain-muffin-using-bakels-plain-muffin-mix-no-egg\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17953,"title":"Plant-Based Burger Patty (Using Bakels Plant-Based Savoury Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/plant-based-burger-patty-using-bakels-plant-based-savoury-mix\/","post_type":"Recipes","access_levels":null},{"id":17951,"title":"Plant-Based Pastry Filling (Using Plant-Based Savoury Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/plant-based-pastry-filling\/","post_type":"Recipes","access_levels":null},{"id":17955,"title":"Plant-Based Pie Filling (Using Bakels Plant-Based Savoury Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/plant-based-pie-filling-using-bakels-plant-based-savoury-mix\/","post_type":"Recipes","access_levels":null},{"id":17956,"title":"Plant-Based Sausage Roll Filling (Using Plant-Based Savoury Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/plant-based-sausage-roll-filling-using-plant-based-savoury-mix\/","post_type":"Recipes","access_levels":"public_access"},{"id":18048,"title":"Plant-Based Yeast Raised Donuts","url":"https:\/\/www.bakels.com.au\/recipes\/plant-based-yeast-raised-donuts\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":15777,"title":"Premium Light Rye Sandwich Bread","url":"https:\/\/www.bakels.com.au\/recipes\/premium-light-rye-sandwich-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":16860,"title":"Premium White Sandwich Bread (Using Fermdor W Classic)","url":"https:\/\/www.bakels.com.au\/recipes\/premium-white-sandwich-bread-using-fermdor-w-classic\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17153,"title":"Princess Cake Muffins (Using Bakels Creme Cake Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/princess-cake-muffins-using-bakels-creme-cake-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16941,"title":"Prune and Cashew Cake (Using Bakels Homestyle Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/prune-and-cashew-cake-using-bakels-homestyle-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16929,"title":"Prune and Port Sour Cream Cake","url":"https:\/\/www.bakels.com.au\/recipes\/prune-and-port-sour-cream-cake\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15730,"title":"Puff Pastry (using Vegetable Pastry Nuggets - Hard Grade)","url":"https:\/\/www.bakels.com.au\/recipes\/puff-pastry-using-vegetable-pastry-nuggets-hard-grade\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15727,"title":"Puff Pastry (using Vegetable Pastry Nuggets - Medium Grade)","url":"https:\/\/www.bakels.com.au\/recipes\/puff-pastry-using-vegetable-pastry-nuggets-medium-grade\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15686,"title":"Puff Pastry Roll","url":"https:\/\/www.bakels.com.au\/products\/puff-pastry-roll\/","post_type":"Products","tax_terms":"Frozen Pastry","sku":"611463","access_levels":"public_access"},{"id":16993,"title":"Pumpkin and Raisin Cake (Using Bakels Homestyle Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/pumpkin-and-raisin-cake-using-bakels-homestyle-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15738,"title":"Quiche","url":"https:\/\/www.bakels.com.au\/recipes\/quiche\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":29649,"title":"Quiche Mix","url":"https:\/\/www.bakels.com.au\/products\/quiche-mix\/","post_type":"Products","tax_terms":"Various Pastry Cooking Products","sku":"731902","access_levels":"public_access"},{"id":16768,"title":"Quiche Shortpaste (Using Pie Base Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/quiche-shortpaste-using-pie-base-concentrate\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15518,"title":"Rapbrim","url":"https:\/\/www.bakels.com.au\/products\/rapbrim\/","post_type":"Products","tax_terms":"Bread Improvers","sku":"257001","access_levels":"public_access"},{"id":17373,"title":"Raspberry Dip (Using Bakels Pettina Raspberry Dip)","url":"https:\/\/www.bakels.com.au\/recipes\/raspberry-dip-using-bakels-pettina-raspberry-dip\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":28888,"title":"Raspberry Flavoured Filling NAFNAC","url":"https:\/\/www.bakels.com.au\/products\/raspberry-flavoured-filling-nafnac\/","post_type":"Products","tax_terms":"Fruit & Fruit Flavoured Fillings","sku":"418213","access_levels":"public_access"},{"id":18035,"title":"Raspberry Flavoured Wrappable Icing Soft MB","url":"https:\/\/www.bakels.com.au\/products\/raspberry-flavoured-wrappable-icing-soft-mb\/","post_type":"Products","tax_terms":"Icings & Icing Sugars","sku":"426212","access_levels":"public_access"},{"id":17296,"title":"Raspberry Jelly Cheesecake [H] (Using Bakels Gourmet Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/raspberry-jelly-cheesecake-using-bakels-gourmet-cheesecake-mix-2\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17298,"title":"Raspberry Jelly Cheesecake [H] (Using Pettina Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/raspberry-jelly-cheesecake-using-pettina-cheesecake-mix-2\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17359,"title":"Raspberry Jelly Cheesecake [I] (Using Bakels Gourmet Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/raspberry-jelly-cheesecake-using-bakels-gourmet-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17301,"title":"Raspberry Jelly Cheesecake [I] (Using Pettina Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/raspberry-jelly-cheesecake-using-pettina-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":28870,"title":"Red Velvet & White Chocolate Cookie","url":"https:\/\/www.bakels.com.au\/products\/red-velvet-white-chocolate-cookie\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"632164","access_levels":"public_access"},{"id":17069,"title":"Red Velvet Cake Mix","url":"https:\/\/www.bakels.com.au\/products\/red-velvet-cake-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"383777, 383778","access_levels":"public_access"},{"id":15754,"title":"Red Velvet Cheesecake Slice","url":"https:\/\/www.bakels.com.au\/recipes\/red-velvet-cheesecake-slice\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15807,"title":"Red Velvet Mud Cake","url":"https:\/\/www.bakels.com.au\/recipes\/red-velvet-mud-cake\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":17130,"title":"Red Velvet Mud Cake (Using Bakels Red Velvet Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/red-velvet-mud-cake-using-bakels-red-velvet-cake-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":16780,"title":"Rich Dark Fruit Cake (Using Cake Margarine - Medium Grade)","url":"https:\/\/www.bakels.com.au\/recipes\/rich-dark-fruit-cake-using-cake-margarine-medium-grade\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16970,"title":"Rich Dark Mud Cake (Using Bakels Rich Dark Mud Cake Conc)","url":"https:\/\/www.bakels.com.au\/recipes\/rich-dark-mud-cake-using-bakels-rich-dark-mud-cake-conc\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17190,"title":"Rich Fruit Cake (Using Bakels Fruit Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/rich-fruit-cake-using-bakels-fruit-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17422,"title":"Ring Bread (Using Artisan 7% Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/ring-bread-using-artisan-7-concentrate\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16835,"title":"Rock Cakes or Raspberry Buns (Using Pettina Scone Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/rock-cakes-or-raspberry-buns-using-pettina-scone-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15801,"title":"Rocky Road Hedgehog Slice (bake)","url":"https:\/\/www.bakels.com.au\/recipes\/rocky-road-hedgehog-slice-bake\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17244,"title":"Rocky Road Hedgehog Slice (Bakels Neutral Hedgehog Slice)","url":"https:\/\/www.bakels.com.au\/recipes\/rocky-road-hedgehog-slice-bakels-neutral-hedgehog-slice\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17787,"title":"Romero Vanilla Slice Mix","url":"https:\/\/www.bakels.com.au\/products\/romero-vanilla-slice-mix\/","post_type":"Products","tax_terms":"Custard and Creme Mixes","sku":"333502","access_levels":"public_access"},{"id":15802,"title":"Royal Icing","url":"https:\/\/www.bakels.com.au\/recipes\/royal-icing\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":16887,"title":"Royal Icing - Alternative Recipe (Using Actiwhite)","url":"https:\/\/www.bakels.com.au\/recipes\/royal-icing-alternative-recipe-using-actiwhite\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":"public_access"},{"id":28915,"title":"RTU Chocolate Icing","url":"https:\/\/www.bakels.com.au\/products\/rtu-chocolate-icing\/","post_type":"Products","tax_terms":"Icings & Icing Sugars","sku":"420733","access_levels":"public_access"},{"id":28901,"title":"RTU Mock Creme","url":"https:\/\/www.bakels.com.au\/products\/rtu-mock-creme\/","post_type":"Products","tax_terms":"Caramel and Creme Fillings","sku":"414653","access_levels":"public_access"},{"id":17511,"title":"RTU Pink Icing MB","url":"https:\/\/www.bakels.com.au\/products\/rtu-pink-icing-mb\/","post_type":"Products","tax_terms":"Icings & Icing Sugars","sku":"420832","access_levels":"public_access"},{"id":18439,"title":"RTU White Icing","url":"https:\/\/www.bakels.com.au\/products\/rtu-white-icing\/","post_type":"Products","tax_terms":"Icings & Icing Sugars","sku":"420632","access_levels":"public_access"},{"id":16952,"title":"Rum 'N' Raisin Brownie Slice (Using Bakels Mud Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/rum-n-raisin-brownie-slice-using-bakels-mud-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17138,"title":"Rum and Raisin Cake Muffins (Using Bakels Creme Cake Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/rum-and-raisin-cake-muffins-using-bakels-creme-cake-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15799,"title":"Rum Gugelhupf","url":"https:\/\/www.bakels.com.au\/recipes\/rum-gugelhupf\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":16769,"title":"Rum Syrup (Cake Margarine - Medium Grade)","url":"https:\/\/www.bakels.com.au\/recipes\/rum-syrup-cake-margarine-medium-grade\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16861,"title":"Rustic European Bread (Using Bakels Fermdor W Classic)","url":"https:\/\/www.bakels.com.au\/recipes\/rustic-european-bread-using-bakels-fermdor-w-classic\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17419,"title":"Rye Ring (Using Artisan 7% Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/rye-ring-using-artisan-7-concentrate\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16932,"title":"Sacher Torte (Using Pettina Chocolate Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/sacher-torte-using-pettina-chocolate-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":18447,"title":"Salty Caramel and White Choc Cookie","url":"https:\/\/www.bakels.com.au\/products\/salty-caramel-and-white-choc-cookie\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"631613 (70g), 631614 (28g)","access_levels":"public_access"},{"id":17106,"title":"Salty Caramel Sauce","url":"https:\/\/www.bakels.com.au\/products\/salty-caramel-sauce\/","post_type":"Products","tax_terms":"Caramel and Creme Fillings","sku":"448013, 448012","access_levels":"public_access"},{"id":17339,"title":"Sausage Roll Meat Filling (Using Fino Meat Pie Seasoning)","url":"https:\/\/www.bakels.com.au\/recipes\/sausage-roll-meat-filling-using-fino-meat-pie-seasoning\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17452,"title":"Savoury Loaf (Using Artisan 7% Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/savoury-loaf-using-artisan-7-concentrate\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15745,"title":"Savoury Scones","url":"https:\/\/www.bakels.com.au\/recipes\/savoury-scones\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17454,"title":"Savoury\/Sweet Plait (Using Artisan 7% Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/savoury-sweet-plait-using-artisan-7-concentrate\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17898,"title":"Scandinavian Rye Bread Mix","url":"https:\/\/www.bakels.com.au\/products\/scandinavian-rye-bread-mix\/","post_type":"Products","tax_terms":"Bread Mixes and Concentrates","sku":"391502","access_levels":"public_access"},{"id":15796,"title":"Scones","url":"https:\/\/www.bakels.com.au\/recipes\/scones\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":"public_access"},{"id":16839,"title":"Scones (Using Pettina Scone Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/scones-using-pettina-scone-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16868,"title":"Seafood Pie Filling (Bakels Cook Up Starch)","url":"https:\/\/www.bakels.com.au\/recipes\/seafood-pie-filling-bakels-cook-up-starch\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16919,"title":"Shortbread (Using Bakels Shortbread Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/shortbread-using-bakels-shortbread-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17460,"title":"Shortbread Fingers","url":"https:\/\/www.bakels.com.au\/products\/shortbread-fingers\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"632155","access_levels":"public_access"},{"id":15554,"title":"Shortpaste Margarine - Medium Grade","url":"https:\/\/www.bakels.com.au\/products\/shortpaste-margarine-medium-grade\/","post_type":"Products","tax_terms":"Pastry Margarines","sku":"166082","access_levels":"public_access"},{"id":17417,"title":"Snoerzel (Using Artisan 7% Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/snoerzel-using-artisan-7-concentrate\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15670,"title":"Sorbex","url":"https:\/\/www.bakels.com.au\/products\/sorbex\/","post_type":"Products","tax_terms":"Preservatives","sku":"271002","access_levels":null},{"id":16933,"title":"Spicy Fruit Cake Muffins (Using Bakels Creme Cake Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/spicy-fruit-cake-muffins-using-bakels-creme-cake-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16935,"title":"Spicy Nutty Apple Mix (Using Bakels Creme Cake Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/spicy-nutty-apple-mix-using-bakels-creme-cake-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16787,"title":"Sponge - Best Quality - Alternative Recipe (Using Wispalett)","url":"https:\/\/www.bakels.com.au\/recipes\/sponge-best-quality-alternative-recipe-using-wispalett\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16778,"title":"Sponge - Best Quality (Using Ovalett)","url":"https:\/\/www.bakels.com.au\/recipes\/sponge-best-quality-using-ovalett\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16781,"title":"Sponge - Best Quality (Using Wispalett)","url":"https:\/\/www.bakels.com.au\/recipes\/sponge-best-quality-using-wispalett\/","post_type":"Recipes","access_levels":null},{"id":16784,"title":"Sponge - Medium Quality - Alternative Recipe (Using Ovalett)","url":"https:\/\/www.bakels.com.au\/recipes\/sponge-medium-quality-alternative-recipe-using-ovalett\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16777,"title":"Sponge - Medium Quality (Using Ovalett)","url":"https:\/\/www.bakels.com.au\/recipes\/sponge-medium-quality-using-ovalett\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15784,"title":"Sponge Rounds and Swiss Rolls","url":"https:\/\/www.bakels.com.au\/recipes\/sponge-rounds-and-swiss-rolls\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16858,"title":"Sponge Rounds and Swiss Rolls (Using Bakels Multi-Purpose Sponge Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/sponge-rounds-and-swiss-rolls-using-bakels-multi-purpose-sponge-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15534,"title":"Sprink Aerosol","url":"https:\/\/www.bakels.com.au\/products\/sprink-aerosol\/","post_type":"Products","tax_terms":"Release Solutions","sku":"132004","access_levels":"public_access"},{"id":15535,"title":"Sprink Bulk","url":"https:\/\/www.bakels.com.au\/products\/sprink-bulk\/","post_type":"Products","tax_terms":"Fats & Oils, Release Solutions","sku":"132103, 132106","access_levels":"public_access"},{"id":17815,"title":"Sprink Bulk No Soy","url":"https:\/\/www.bakels.com.au\/products\/sprink-bulk-no-soy\/","post_type":"Products","tax_terms":"Fats & Oils, Release Solutions","sku":"132112, 132113","access_levels":"public_access"},{"id":15757,"title":"Stabilised Fresh Cream","url":"https:\/\/www.bakels.com.au\/recipes\/stabilised-fresh-cream\/","post_type":"Recipes","access_levels":null},{"id":17234,"title":"Steak and Kidney Pie Filling (Using Bakels Cook Up Starch)","url":"https:\/\/www.bakels.com.au\/recipes\/steak-and-kidney-pie-filling-using-bakels-cook-up-starch\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17232,"title":"Steak and Mushroom Pie Filling (Using Bakels Cook Up Starch)","url":"https:\/\/www.bakels.com.au\/recipes\/steak-and-mushroom-pie-filling-using-bakels-cook-up-starch\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16900,"title":"Sticky Date Cake (Using Bakels Sticky Date Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/sticky-date-cake-using-bakels-sticky-date-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":"public_access"},{"id":16978,"title":"Sticky Date Cake or Pudding (Bakels Homestyle Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/sticky-date-cake-or-pudding-bakels-homestyle-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16901,"title":"Sticky Date Pudding (Using Bakels Sticky Date Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/sticky-date-pudding-using-bakels-sticky-date-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":"public_access"},{"id":15628,"title":"Strawberry Flavoured Fondant","url":"https:\/\/www.bakels.com.au\/products\/strawberry-flavoured-fondant\/","post_type":"Products","tax_terms":"Fondants, Chocolate, Ganache & Truffles","sku":"425513","access_levels":"public_access"},{"id":17372,"title":"Strawberry Mousse (Using Bakels Strawberry Mousse Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/strawberry-mousse-using-bakels-strawberry-mousse-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15792,"title":"Strawberry Mousse (using Pettina Fond Suisse)","url":"https:\/\/www.bakels.com.au\/recipes\/strawberry-mousse\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":17311,"title":"Strawberry Torte\/Cheesecake (Using Bakels Gourmet Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/strawberry-torte-cheesecake-using-bakels-gourmet-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15808,"title":"Strawberry Torte\/Cheesecake (using Pettina Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/strawberry-torte-cheesecake\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16771,"title":"Streusel Topping (Using Cake Margarine - Medium Grade)","url":"https:\/\/www.bakels.com.au\/recipes\/streusel-topping-using-cake-margarine-medium-grade\/","post_type":"Recipes","access_levels":null},{"id":17144,"title":"Sultana Cake Muffins (Using Bakels All-In Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/sultana-cake-muffins-using-bakels-all-in-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17279,"title":"Sultana Loaf (Using Bakels Gluten Free Baking Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/sultana-loaf-using-bakels-gluten-free-baking-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17423,"title":"Sunflower Bread (Using Artisan 7% Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/sunflower-bread-using-artisan-7-concentrate\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17223,"title":"Super Glaze Neutral","url":"https:\/\/www.bakels.com.au\/products\/super-glaze-neutral\/","post_type":"Products","tax_terms":"Glazes, Piping Gels & Dips","sku":"346574","access_levels":"public_access"},{"id":17741,"title":"Super Glossy Natural","url":"https:\/\/www.bakels.com.au\/products\/super-glossy-natural\/","post_type":"Products","tax_terms":"Glazes, Piping Gels & Dips","sku":"345401","access_levels":"public_access"},{"id":18247,"title":"Sweden","url":"https:\/\/www.bakels.com.au\/services\/baking-centres\/sweden\/","post_type":"Baking Centres","access_levels":null},{"id":16841,"title":"Sweet Pinwheel Scones (Using Pettina Scone Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/sweet-pinwheel-scones-using-pettina-scone-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15728,"title":"Sweet Shortpaste (using Shortpaste Margarine - Medium Grade)","url":"https:\/\/www.bakels.com.au\/recipes\/sweet-shortpaste-using-shortpaste-margarine-medium-grade\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16774,"title":"Sweet Yeast Dough (Using Baktem Red V)","url":"https:\/\/www.bakels.com.au\/recipes\/sweet-yeast-dough-using-baktem-red-v\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":"public_access"},{"id":3389,"title":"Switzerland","url":"https:\/\/www.bakels.com.au\/services\/baking-centres\/switzerland\/","post_type":"Baking Centres","access_levels":null},{"id":3392,"title":"Thailand","url":"https:\/\/www.bakels.com.au\/services\/baking-centres\/thailand\/","post_type":"Baking Centres","access_levels":null},{"id":16795,"title":"Tiger Bread (Using Bakels Tiger Paste Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/tiger-bread-using-bakels-tiger-paste-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16690,"title":"Tinclear","url":"https:\/\/www.bakels.com.au\/products\/tinclear\/","post_type":"Products","tax_terms":"Release Solutions","sku":"134804","access_levels":"public_access"},{"id":28851,"title":"Tincol","url":"https:\/\/www.bakels.com.au\/products\/tincol\/","post_type":"Products","tax_terms":"Release Solutions","sku":"133105, 133107","access_levels":"public_access"},{"id":15537,"title":"Tinmax Cake","url":"https:\/\/www.bakels.com.au\/products\/tinmax-cake\/","post_type":"Products","tax_terms":"Release Solutions","sku":"135902","access_levels":"public_access"},{"id":17380,"title":"Tiramisu Cheesecake (Using Bakels Tiramisu Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/tiramisu-cheesecake-using-bakels-tiramisu-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17379,"title":"Tiramisu Mousse (Using Bakels Tiramisu Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/tiramisu-mousse-using-bakels-tiramisu-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17235,"title":"Tomato and Onion Pie Filling (Using Bakels Cook Up Starch)","url":"https:\/\/www.bakels.com.au\/recipes\/tomato-and-onion-pie-filling-using-bakels-cook-up-starch\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16958,"title":"Triple Choc Muffin (Using Bakels Chocolate Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/triple-choc-muffin-using-bakels-chocolate-muffin-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17310,"title":"Tropical Cheesecake (Using Gourmet Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/tropical-cheesecake-using-gourmet-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17290,"title":"Tropical Cheesecake (Using Pettina Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/tropical-cheesecake-using-pettina-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17203,"title":"Tropical Fruit Slice (Using Pettina Kokomix)","url":"https:\/\/www.bakels.com.au\/recipes\/tropical-fruit-slice-using-pettina-kokomix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17314,"title":"Tropical Yogurt Slice (Using Pettina Fond Suisse)","url":"https:\/\/www.bakels.com.au\/recipes\/tropical-yogurt-slice-using-pettina-fond-suisse\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17257,"title":"Turkish Bread and Rolls (Using Bakels Ciabatta Bread Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/turkish-bread-and-rolls-using-bakels-ciabatta-bread-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17416,"title":"Turkish\/Turkishina (Using Artisan 7% Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/turkish-turkishina-using-artisan-7-concentrate\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17914,"title":"Value Cookie Choc Chip","url":"https:\/\/www.bakels.com.au\/products\/value-cookie-choc-chip\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"632742 (25g)","access_levels":"public_access"},{"id":16876,"title":"Vanilla Custard (Using Bakels Instant Custard Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/vanilla-custard-using-bakels-instant-custard-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16865,"title":"Vanilla Custard (Using Bakels Instant Snowflake Custard Mix NAFNAC)","url":"https:\/\/www.bakels.com.au\/recipes\/vanilla-custard-using-bakels-instant-snowflake-custard-mix-nafnac\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":18042,"title":"Vanilla Patisserie Filling (Using Bakels Vanilla Patisserie Filling Mix NAFNAC)","url":"https:\/\/www.bakels.com.au\/recipes\/vanilla-patisserie-filling-using-bakels-vanilla-patisserie-filling-mix-nafnac\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":28880,"title":"Vanilla Rainbow Cookie","url":"https:\/\/www.bakels.com.au\/products\/vanilla-rainbow-cookie\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"633362","access_levels":"public_access"},{"id":16807,"title":"Vanilla Slice Filling (Using Kramess Vanilla Slice Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/vanilla-slice-filling-using-kramess-vanilla-slice-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":16883,"title":"Vanilla Slice Filling (Using Romero Vanilla Slice Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/vanilla-slice-filling-using-romero-vanilla-slice-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17016,"title":"Vegan Cake Mix","url":"https:\/\/www.bakels.com.au\/products\/vegan-cake-mix\/","post_type":"Products","tax_terms":"Sponge & Cake Premixes","sku":"381501","access_levels":"public_access"},{"id":16902,"title":"Vegan Cake Mix (Using Bakels Vegan Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/vegan-cake-mix-using-bakels-vegan-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16811,"title":"Vegetable and Meat Pie Filling (Using Bakels Cook Up Starch)","url":"https:\/\/www.bakels.com.au\/recipes\/vegetable-and-meat-pie-filling-using-bakels-cook-up-starch\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15573,"title":"Vegetable Cake Margarine","url":"https:\/\/www.bakels.com.au\/products\/vegetable-cake-margarine\/","post_type":"Products","tax_terms":"Sponge & Cake Emulsifiers- Cake- Margarines","sku":"166131","access_levels":"public_access"},{"id":15558,"title":"Vegetable Pastry Nuggets - Hard Grade","url":"https:\/\/www.bakels.com.au\/products\/vegetable-pastry-nuggets-hard-grade\/","post_type":"Products","tax_terms":"Pastry Margarines","sku":"166121","access_levels":"public_access"},{"id":15553,"title":"Vegetable Pastry Nuggets - Medium Grade","url":"https:\/\/www.bakels.com.au\/products\/vegetable-pastry-nuggets-medium-grade\/","post_type":"Products","tax_terms":"Pastry Margarines","sku":"166021","access_levels":"public_access"},{"id":16813,"title":"Vegetable Pie Filling (Using Bakels Cook Up Starch)","url":"https:\/\/www.bakels.com.au\/recipes\/vegetable-pie-filling-using-bakels-cook-up-starch\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15512,"title":"Voltem","url":"https:\/\/www.bakels.com.au\/products\/voltem\/","post_type":"Products","tax_terms":"Specialised Fats","sku":"171001","access_levels":"public_access"},{"id":29652,"title":"Waffle Mix","url":"https:\/\/www.bakels.com.au\/products\/waffle-mix\/","post_type":"Products","tax_terms":"Various Pastry Cooking Products","sku":"378951","stockist_sku":"","access_levels":"public_access"},{"id":17435,"title":"Walnut and Raisin Cake (Using Bakels Carrot Cake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/walnut-and-raisin-cake-using-bakels-carrot-cake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16885,"title":"Walnut Fruited Slice (Using Actiwhite)","url":"https:\/\/www.bakels.com.au\/recipes\/walnut-fruited-slice-using-actiwhite\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15701,"title":"Whip 'n' Ice","url":"https:\/\/www.bakels.com.au\/products\/whip-n-ice\/","post_type":"Products","tax_terms":"Caramel and Creme Fillings, Toppings","sku":"414144","access_levels":"public_access"},{"id":17368,"title":"White Bread and Rolls (Using Bakels Advance Bread and Roll Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/white-bread-and-rolls-using-bakels-advance-bread-and-roll-concentrate\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17369,"title":"White Bread and Rolls (Using Bakels Sour Bread Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/white-bread-and-rolls-using-bakels-sour-bread-concentrate\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17365,"title":"White Bread and Rolls (Using Bakels Spelt Bread Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/white-bread-and-rolls-using-bakels-spelt-bread-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":18625,"title":"White Chocolate & Cranberry Cookie (28g)","url":"https:\/\/www.bakels.com.au\/products\/white-chocolate-cranberry-cookie-28g\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"631214 (28g)","access_levels":"public_access"},{"id":28860,"title":"White Chocolate & Cranberry Cookie (70g)","url":"https:\/\/www.bakels.com.au\/products\/white-chocolate-cranberry-cookie-70g\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"631212","access_levels":"public_access"},{"id":18623,"title":"White Chocolate & Macadamia Cookie (28g)","url":"https:\/\/www.bakels.com.au\/products\/white-chocolate-macadamia-cookie-28g\/","post_type":"Products","tax_terms":"Frozen Cookies","sku":"631464, 631462","access_levels":"public_access"},{"id":15793,"title":"White Chocolate Fudge Icing","url":"https:\/\/www.bakels.com.au\/recipes\/white-chocolate-fudge-icing\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":17376,"title":"White Chocolate Fudge Icing (Using Fondant Standard - White)","url":"https:\/\/www.bakels.com.au\/recipes\/white-chocolate-fudge-icing-using-fondant-standard-white\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17384,"title":"White Chocolate Fudge Icing (Using Fondant White - Extra Soft)","url":"https:\/\/www.bakels.com.au\/recipes\/white-chocolate-fudge-icing-using-fondant-white-extra-soft\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17349,"title":"White Chocolate Mousse (Using Bakels White Mousse Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/white-chocolate-mousse-using-bakels-white-mousse-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15756,"title":"White Mud Cake","url":"https:\/\/www.bakels.com.au\/recipes\/white-mud-cake\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":15577,"title":"Wispalett Special - MB","url":"https:\/\/www.bakels.com.au\/products\/wispalett-special\/","post_type":"Products","tax_terms":"Sponge & Cake Emulsifiers- Cake- Margarines","sku":"214101","access_levels":"public_access"},{"id":16837,"title":"Yeast Donuts (Using Bakels Soft Donut Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/yeast-donuts-using-bakels-soft-donut-concentrate\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":18437,"title":"Yeast Raised Donut","url":"https:\/\/www.bakels.com.au\/recipes\/yeast-raised-donut\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":16773,"title":"Yeast Raised Donut (Using Baktem Red V)","url":"https:\/\/www.bakels.com.au\/recipes\/yeast-raised-donut-using-baktem-red-v\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":"public_access"},{"id":18433,"title":"Yeast Raised Donut (YRD) 25% Concentrate Paste","url":"https:\/\/www.bakels.com.au\/products\/yrd-25-concentrate-paste\/","post_type":"Products","tax_terms":"Donut Mixes and Concentrates","sku":"378572","access_levels":"public_access"},{"id":16836,"title":"Yeast Raised Donuts (Using Bakels Yeast Raised Donut Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/yeast-donuts-using-bakels-yeast-raised-donut-mix\/","post_type":"Recipes","tax_terms":"Patisserie, Bakery","access_levels":null},{"id":17294,"title":"Yoghurt Cheesecake (Using Bakels Gourmet Cheesecake Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/yoghurt-cheesecake-using-bakels-gourmet-cheesecake-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17356,"title":"Yoghurt Cheesecake (Using Pettina Cheesecake Mix & Pettina Fond Suisse)","url":"https:\/\/www.bakels.com.au\/recipes\/yoghurt-cheesecake-using-pettina-cheesecake-mix-pettina-fond-suisse\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":16940,"title":"Yoghurt Poppy Orange Cake (Using Bakels Creme Cake Muffin Mix)","url":"https:\/\/www.bakels.com.au\/recipes\/yoghurt-poppy-orange-cake-using-bakels-creme-cake-muffin-mix\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17312,"title":"Yoghurt Torte - Basic Recipe (Using Pettina Fond Suisse)","url":"https:\/\/www.bakels.com.au\/recipes\/yoghurt-torte-basic-recipe-using-pettina-fond-suisse\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null},{"id":17451,"title":"Zurich Bread (Using Artisan 7% Concentrate)","url":"https:\/\/www.bakels.com.au\/recipes\/zurich-bread-using-artisan-7-concentrate\/","post_type":"Recipes","tax_terms":"Bakery, Patisserie","access_levels":null}] ) );
+                </script><script type='text/javascript'>
+                    var imdmsTypeaheadPageTaxonomyJSON = 'typeaheadPageTaxonomyJSON_en';
+                    localStorage.setItem( 'typeaheadPageTaxonomyJSON_en', JSON.stringify( [{"id":85,"title":"About","url":"https:\/\/www.bakels.com.au\/about\/","post_type":"Pages","tax_terms":"","sku":"","access_levels":"public_access"},{"id":3556,"title":"Australian Bakels","url":"https:\/\/www.bakels.com.au\/local\/","post_type":"Pages","tax_terms":"","sku":"","access_levels":"public_access"},{"id":103,"title":"Baking Centres","url":"https:\/\/www.bakels.com.au\/baking-centres\/","post_type":"Pages","tax_terms":"","sku":"","access_levels":"public_access"},{"id":93,"title":"Centres of Competence","url":"https:\/\/www.bakels.com.au\/services\/centres-of-competence\/","post_type":"Pages","tax_terms":"","sku":"","access_levels":"public_access"},{"id":79,"title":"Core Values","url":"https:\/\/www.bakels.com.au\/about\/core-values\/","post_type":"Pages","tax_terms":"","sku":"","access_levels":"public_access"},{"id":81,"title":"Facts & Figures","url":"https:\/\/www.bakels.com.au\/about\/facts-figures\/","post_type":"Pages","tax_terms":"","sku":"","access_levels":"public_access"},{"id":80,"title":"History","url":"https:\/\/www.bakels.com.au\/about\/history\/","post_type":"Pages","tax_terms":"","sku":"","access_levels":"public_access"},{"id":76,"title":"Jobs","url":"https:\/\/www.bakels.com.au\/about\/jobs\/","post_type":"Pages","tax_terms":"","sku":"","access_levels":"public_access"},{"id":87,"title":"Our Customers","url":"https:\/\/www.bakels.com.au\/about\/our-customers\/","post_type":"Pages","tax_terms":"","sku":"","access_levels":null},{"id":89,"title":"Services","url":"https:\/\/www.bakels.com.au\/services\/","post_type":"Pages","tax_terms":"","sku":"","access_levels":"public_access"},{"id":3664,"title":"Raising Agents","url":"https:\/\/www.bakels.com.au\/product-category\/raising-agents\/","post_type":"Product Categories"},{"id":4914,"title":"Muffin Mixes","url":"https:\/\/www.bakels.com.au\/product-category\/muffin-mixes\/","post_type":"Product Categories"},{"id":3641,"title":"Bread Mixes and Concentrates","url":"https:\/\/www.bakels.com.au\/product-category\/bread-mixes-concentrates\/","post_type":"Product Categories"},{"id":3634,"title":"Bread Improvers","url":"https:\/\/www.bakels.com.au\/product-category\/bread-improvers\/","post_type":"Product Categories"},{"id":1757,"title":"Bread, Roll & Morning Goods","url":"https:\/\/www.bakels.com.au\/product-category\/bread-roll-morning-goods\/","post_type":"Product Categories"},{"id":3656,"title":"Cheesecake Mixes","url":"https:\/\/www.bakels.com.au\/product-category\/cheesecake-mixes\/","post_type":"Product Categories"},{"id":4913,"title":"Cookie & Biscuit Mixes","url":"https:\/\/www.bakels.com.au\/product-category\/cookie-biscuit-mixes\/","post_type":"Product Categories"},{"id":3648,"title":"Caramel and Creme Fillings","url":"https:\/\/www.bakels.com.au\/product-category\/caramel-and-creme-fillings\/","post_type":"Product Categories"},{"id":4968,"title":"Custard and Creme Mixes","url":"https:\/\/www.bakels.com.au\/product-category\/custard-and-creme-mixes\/","post_type":"Product Categories"},{"id":4398,"title":"Fats & Oils","url":"https:\/\/www.bakels.com.au\/product-category\/fats-oils\/","post_type":"Product Categories"},{"id":3661,"title":"Flavouring Pastes, Essences & Colours","url":"https:\/\/www.bakels.com.au\/product-category\/flavouring-pastes-essences-colours\/","post_type":"Product Categories"},{"id":3657,"title":"Fondants, Chocolate, Ganache & Truffles","url":"https:\/\/www.bakels.com.au\/product-category\/fondants-chocolate-ganache-truffles\/","post_type":"Product Categories"},{"id":3669,"title":"Frozen Cookies","url":"https:\/\/www.bakels.com.au\/product-category\/frozen-cookies\/","post_type":"Product Categories"},{"id":3667,"title":"Frozen Pastry","url":"https:\/\/www.bakels.com.au\/product-category\/frozen-pastry\/","post_type":"Product Categories"},{"id":3651,"title":"Fruit & Fruit Flavoured Fillings","url":"https:\/\/www.bakels.com.au\/product-category\/fruit-flavoured-fillings\/","post_type":"Product Categories"},{"id":3658,"title":"Glazes, Piping Gels & Dips","url":"https:\/\/www.bakels.com.au\/product-category\/glazes-piping-gels-dips\/","post_type":"Product Categories"},{"id":3646,"title":"Gluten Free Products","url":"https:\/\/www.bakels.com.au\/product-category\/gluten-free-products\/","post_type":"Product Categories"},{"id":3659,"title":"Icings & Icing Sugars","url":"https:\/\/www.bakels.com.au\/product-category\/icings-icing-sugars\/","post_type":"Product Categories"},{"id":3666,"title":"Meringue and Mallow Mixes","url":"https:\/\/www.bakels.com.au\/product-category\/meringue-and-mallow-mixes\/","post_type":"Product Categories"},{"id":4971,"title":"Mousse Mixes","url":"https:\/\/www.bakels.com.au\/product-category\/mousse-mixes\/","post_type":"Product Categories"},{"id":3642,"title":"Pastry Margarines","url":"https:\/\/www.bakels.com.au\/product-category\/pastry-margarines\/","post_type":"Product Categories"},{"id":3663,"title":"Preservatives","url":"https:\/\/www.bakels.com.au\/product-category\/preservatives\/","post_type":"Product Categories"},{"id":3638,"title":"Release Solutions","url":"https:\/\/www.bakels.com.au\/product-category\/release-solutions\/","post_type":"Product Categories"},{"id":3650,"title":"Slice Mixes & Bases","url":"https:\/\/www.bakels.com.au\/product-category\/slice-mixes-bases\/","post_type":"Product Categories"},{"id":3625,"title":"Specialised Fats","url":"https:\/\/www.bakels.com.au\/product-category\/specialised-bread-bun-fats\/","post_type":"Product Categories"},{"id":3644,"title":"Specialised Pie & Potato Products","url":"https:\/\/www.bakels.com.au\/product-category\/specialised-pie-potato-products\/","post_type":"Product Categories"},{"id":3645,"title":"Sponge & Cake Emulsifiers- Cake- Margarines","url":"https:\/\/www.bakels.com.au\/product-category\/sponge-cake-emulsifiers-cake-margarines\/","post_type":"Product Categories"},{"id":4889,"title":"Sponge & Cake Premixes","url":"https:\/\/www.bakels.com.au\/product-category\/sponge-cake-premixes\/","post_type":"Product Categories"},{"id":5218,"title":"Toppings","url":"https:\/\/www.bakels.com.au\/product-category\/toppings\/","post_type":"Product Categories"},{"id":3631,"title":"Bread Toppings","url":"https:\/\/www.bakels.com.au\/product-category\/bread-toppings\/","post_type":"Product Categories"},{"id":3665,"title":"Various Pastry Cooking Products","url":"https:\/\/www.bakels.com.au\/product-category\/various-pastry-cooking-products\/","post_type":"Product Categories"},{"id":5541,"title":"Donut Mixes and Concentrates","url":"https:\/\/www.bakels.com.au\/product-category\/donut-mixes-and-concentrates\/","post_type":"Product Categories"},{"id":5542,"title":"Yeast","url":"https:\/\/www.bakels.com.au\/product-category\/yeast\/","post_type":"Product Categories"},{"id":5543,"title":"Sourdough Products","url":"https:\/\/www.bakels.com.au\/product-category\/sourdough-products\/","post_type":"Product Categories"},{"id":5544,"title":"Cake and Sponge","url":"https:\/\/www.bakels.com.au\/product-category\/cake-and-sponge\/","post_type":"Product Categories"},{"id":5545,"title":"Cookie and Biscuit","url":"https:\/\/www.bakels.com.au\/product-category\/cookie-and-biscuit\/","post_type":"Product Categories"},{"id":5546,"title":"Confectionary","url":"https:\/\/www.bakels.com.au\/product-category\/confectionary\/","post_type":"Product Categories"},{"id":1796,"title":"Bakery","url":"https:\/\/www.bakels.com.au\/recipe-category\/bakery\/","post_type":"Recipe Categories"},{"id":1797,"title":"Patisserie","url":"https:\/\/www.bakels.com.au\/recipe-category\/patisserie\/","post_type":"Recipe Categories"}] ) );
+                </script><script type='text/javascript'>
+        var ualType = 0, ualRestrictedLevels = ["subscriber_access","staff_access"];
+    </script>	<script>
+	function copyClipboard() {
+		let copyTextarea = document.getElementById('clipboard');
+
+		copyTextarea.select();
+		document.execCommand('copy');
+		this.focus();
+	}
+
+	function copyClipboardMobile() {
+		let copyTextarea = document.getElementById('clipboard-mobile');
+
+		copyTextarea.select();
+		document.execCommand('copy');
+		this.focus();
+	}
+	</script>
+    	<script>
+   		var countrySelected = "AU";
+	</script>
+    <script></script><meta name="generator" content="Powered by WPBakery Page Builder - drag and drop page builder for WordPress."/>
+			<script type='text/javascript'>
+		        /* <![CDATA[ */
+		        var stockist_lang =  'en';
+		        /* ]]> */
+	     	</script>
+
+		<noscript><style> .wpb_animate_when_almost_visible { opacity: 1; }</style></noscript>        <link rel="stylesheet" href="https://use.typekit.net/tnw7zdv.css">
+
+                <!--[if lte IE 11]>
+        <script type="text/javascript">
+            window.location = "/browser-upgrade/";
+        </script>
+        <![endif]-->
+            </head>
+
+    <body class="recipes-template-default single single-recipes postid-17953 full-width-content bakels-en site-21 wpb-js-composer js-comp-ver-7.6 vc_responsive">
+
+        
+    	<!-- BEGIN CONTAINER -->
+      	<div class="wrapper">
+        
+<div class="header-top ">
+	<div class="container">
+		<div class="row">
+						<div class="col-xl-7 col-lg-6 d-lg-flex d-none justify-content-end header-center offset-lg-3 offset-xl-2">
+				<nav class="navbar top-nav navbar-expand" id="top-nav">
+					<div class="top-navbar navbar-collapse">
+						<ul id="menu-primary-menu" class="navbar-nav"><li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-211" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-211 nav-item"><a title="Jobs" href="https://www.bakels.com.au/about/jobs/" class="nav-link">Jobs</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-212" class="menu-item menu-item-type-post_type menu-item-object-page current_page_parent menu-item-212 nav-item"><a title="News" href="https://www.bakels.com.au/news/" class="nav-link">News</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-299" class="menu-item menu-item-type-post_type_archive menu-item-object-stockist menu-item-299 nav-item"><a title="Where to buy" href="https://www.bakels.com.au/stockist/" class="nav-link">Where to buy</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-210" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-210 nav-item"><a title="Contact" href="https://www.bakels.com.au/contact/" class="nav-link">Contact</a></li>
+</ul>
+						<div id="account-nav" class="navbar account-nav navbar-expand-sm d-inline-block">
+							<ul class="navbar-nav">
+								<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" class="menu-item menu-item-type-post_type menu-item-object-page nav-item">
+									<a title="My Bakels" href="https://www.bakels.com.au/my-bakels/" class="dropdown-toggle nav-link" data-toggle="dropdown" role="button">My Bakels</a>
+									<ul id="menu-logged-out-menu" class="dropdown-menu loggedout-nav"><li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-218" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-218 nav-item"><a title="Login" href="https://www.bakels.com.au/my-bakels/login/" class="nav-link">Login</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-217" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-217 nav-item"><a title="Register" href="https://www.bakels.com.au/my-bakels/register/" class="nav-link">Register</a></li>
+</ul>								</li>
+							</ul>
+						</div>
+					</div>
+				</nav>
+			</div>
+			<div class="col-lg-3 d-lg-block d-none header-right">
+						<form role="search" method="get" id="headertop-searchform" class="searchform search-form typeahead__form" action="https://www.bakels.com.au">
+			<div class="typeahead__container">
+				<div class="typeahead__field">
+					<div class="typeahead__query">
+						<label class="screen-reader-text" for="headertop-s" style="display: none;">Search:</label>
+						<input name="s" type="search" value="" class="search-typeahead" id="headertop-s" placeholder="Search..." autocomplete="off">
+					</div>
+					<div class="typeahead__button">
+						<button type="submit" id="headertop-searchsubmit" class="btn btn-search">Search</button>
+					</div>
+				</div>
+			</div>
+		</form>
+
+				</div>
+		</div>
+	</div>
+</div>
+
+<header class="site-header" itemscope="" itemtype="https://schema.org/WPHeader">
+	<div class="container">
+		<div class="row">
+			<div class="col-2 d-lg-none d-flex mobile-btn">
+				<button class="menu-btn" id="responsive-menu">
+					<img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/hamburger-icon.svg" alt="Menu">
+					<!-- <span>Menu</span> -->
+				</button>
+			</div>
+
+			<div class="col-lg-3 col-8 site-logo text-xs-center">
+				<a href="https://www.bakels.com.au" title="Australian Bakels" class="site-title">
+					<img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/logo-blue-new.svg" alt="Australian Bakels" class="dnp d-lg-inline-block d-none">
+					<img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/logo-responsive-blue.svg" alt="Australian Bakels" class="dnp d-lg-none d-inline-block">
+					<img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/logo-blue-new.svg" alt="Australian Bakels" class="print-logo">
+				</a>
+
+				<div class="mobile-search">
+							<form role="search" method="get" id="logo-searchform" class="searchform search-form typeahead__form" action="https://www.bakels.com.au">
+			<div class="typeahead__container">
+				<div class="typeahead__field">
+					<div class="typeahead__query">
+						<label class="screen-reader-text" for="logo-s" style="display: none;">Search:</label>
+						<input name="s" type="search" value="" class="search-typeahead" id="logo-s" placeholder="Search..." autocomplete="off">
+					</div>
+					<div class="typeahead__button">
+						<button type="submit" id="logo-searchsubmit" class="btn btn-search">Search</button>
+					</div>
+				</div>
+			</div>
+		</form>
+
+					</div>
+			</div>
+
+			<div class="col-lg-9 col-2 header-right text-xs-right">
+				<button class="d-lg-none d-inline-block search-btn" id="search-toggle">Search</button>
+
+				<nav class="primary-nav navbar-mega navbar-expand-lg d-lg-block d-none navbar-special" id="nav-primary" itemscope="" itemtype="https://schema.org/SiteNavigationElement" aria-label="Main navigation">
+					<div class="navbar-collapse">
+						<ul id="menu-main-menu" class="navbar-nav navbar-nav-mega"><li id="menu-item-219" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-219 nav-item dropdown dropdown-mega product-category"><a title="Products" href="https://www.bakels.com.au/products/" data-toggle="dropdown" id="219" aria-haspopup="true" role="button" class="nav-link">Products <span class="caret hidden-xs"></span></a>
+<div  class="dropdown-menu "  id="drop-219" aria-labelledby="menu-item-219"><div class="container"><div class="row"><div class="col-3 dropdown-excerpt"><h4>Products</h4><p>Bakels develop, manufacture and distribute innovative ingredients and solutions for bakers and patissiers across all five continents.</p><a href="https://www.bakels.com.au/products/" class="btn btn-opaque btn-opaque-orange btn-icon-right btn-fa-angle-right">View all products</a></div><div class="col-9 dropdown-content"><ul>
+	<li id="menu-item-11" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-11 nav-item nav-item-col-1 menu-item-has-children menu-item-parent-1757"><a title="Bread, Roll &amp; Morning Goods" href="https://www.bakels.com.au/product-category/bread-roll-morning-goods/" class="nav-link"><span class="align-middle">Bread, Roll &amp; Morning Goods</span></a><ul class="second-level-terms"><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3641"><a href="https://www.bakels.com.au/product-category/bread-mixes-concentrates/">Bread Mixes and Concentrates</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3634"><a href="https://www.bakels.com.au/product-category/bread-improvers/">Bread Improvers</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3631"><a href="https://www.bakels.com.au/product-category/bread-toppings/">Bread Toppings</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-5541"><a href="https://www.bakels.com.au/product-category/donut-mixes-and-concentrates/">Donut Mixes and Concentrates</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-5542"><a href="https://www.bakels.com.au/product-category/yeast/">Yeast</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-5543"><a href="https://www.bakels.com.au/product-category/sourdough-products/">Sourdough Products</a></li></ul></li>
+	<li id="menu-item-12" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-12 nav-item nav-item-col-1 menu-item-has-children menu-item-parent-4398"><a title="Fats &amp; Oils" href="https://www.bakels.com.au/product-category/fats-oils/" class="nav-link"><span class="align-middle">Fats &amp; Oils</span></a><ul class="second-level-terms"><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3642"><a href="https://www.bakels.com.au/product-category/pastry-margarines/">Pastry Margarines</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3638"><a href="https://www.bakels.com.au/product-category/release-solutions/">Release Solutions</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3625"><a href="https://www.bakels.com.au/product-category/specialised-bread-bun-fats/">Specialised Fats</a></li></ul></li>
+	<li id="menu-item-13" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-13 nav-item nav-item-col-1"><a title="Frozen Pastry" href="https://www.bakels.com.au/product-category/frozen-pastry/" class="nav-link"><span class="align-middle">Frozen Pastry</span></a></li>
+	<li id="menu-item-14" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-14 nav-item nav-item-col-1"><a title="Gluten Free Products" href="https://www.bakels.com.au/product-category/gluten-free-products/" class="nav-link"><span class="align-middle">Gluten Free Products</span></a></li>
+	<li id="menu-item-15" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-15 nav-item nav-item-col-1"><a title="Preservatives" href="https://www.bakels.com.au/product-category/preservatives/" class="nav-link"><span class="align-middle">Preservatives</span></a></li>
+	<li id="menu-item-16" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-16 nav-item nav-item-col-1"><a title="Specialised Pie &amp; Potato Products" href="https://www.bakels.com.au/product-category/specialised-pie-potato-products/" class="nav-link"><span class="align-middle">Specialised Pie &amp; Potato Products</span></a></li>
+	<li id="menu-item-17" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-17 nav-item nav-item-col-1"><a title="Various Pastry Cooking Products" href="https://www.bakels.com.au/product-category/various-pastry-cooking-products/" class="nav-link"><span class="align-middle">Various Pastry Cooking Products</span></a></li>
+	<li id="menu-item-18" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-18 nav-item nav-item-col-1 menu-item-has-children menu-item-parent-5544"><a title="Cake and Sponge" href="https://www.bakels.com.au/product-category/cake-and-sponge/" class="nav-link"><span class="align-middle">Cake and Sponge</span></a><ul class="second-level-terms"><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3664"><a href="https://www.bakels.com.au/product-category/raising-agents/">Raising Agents</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-4914"><a href="https://www.bakels.com.au/product-category/muffin-mixes/">Muffin Mixes</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3645"><a href="https://www.bakels.com.au/product-category/sponge-cake-emulsifiers-cake-margarines/">Sponge &amp; Cake Emulsifiers- Cake- Margarines</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-4889"><a href="https://www.bakels.com.au/product-category/sponge-cake-premixes/">Sponge &amp; Cake Premixes</a></li></ul></li>
+	<li id="menu-item-19" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-19 nav-item nav-item-col-1 menu-item-has-children menu-item-parent-5545"><a title="Cookie and Biscuit" href="https://www.bakels.com.au/product-category/cookie-and-biscuit/" class="nav-link"><span class="align-middle">Cookie and Biscuit</span></a><ul class="second-level-terms"><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-4913"><a href="https://www.bakels.com.au/product-category/cookie-biscuit-mixes/">Cookie &amp; Biscuit Mixes</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3669"><a href="https://www.bakels.com.au/product-category/frozen-cookies/">Frozen Cookies</a></li></ul></li>
+	<li id="menu-item-20" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-20 nav-item nav-item-col-1 menu-item-has-children menu-item-parent-5546"><a title="Confectionary" href="https://www.bakels.com.au/product-category/confectionary/" class="nav-link"><span class="align-middle">Confectionary</span></a><ul class="second-level-terms"><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3656"><a href="https://www.bakels.com.au/product-category/cheesecake-mixes/">Cheesecake Mixes</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3648"><a href="https://www.bakels.com.au/product-category/caramel-and-creme-fillings/">Caramel and Creme Fillings</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-4968"><a href="https://www.bakels.com.au/product-category/custard-and-creme-mixes/">Custard and Creme Mixes</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3661"><a href="https://www.bakels.com.au/product-category/flavouring-pastes-essences-colours/">Flavouring Pastes, Essences &amp; Colours</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3657"><a href="https://www.bakels.com.au/product-category/fondants-chocolate-ganache-truffles/">Fondants, Chocolate, Ganache &amp; Truffles</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3651"><a href="https://www.bakels.com.au/product-category/fruit-flavoured-fillings/">Fruit &amp; Fruit Flavoured Fillings</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3658"><a href="https://www.bakels.com.au/product-category/glazes-piping-gels-dips/">Glazes, Piping Gels &amp; Dips</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3659"><a href="https://www.bakels.com.au/product-category/icings-icing-sugars/">Icings &amp; Icing Sugars</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3666"><a href="https://www.bakels.com.au/product-category/meringue-and-mallow-mixes/">Meringue and Mallow Mixes</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-4971"><a href="https://www.bakels.com.au/product-category/mousse-mixes/">Mousse Mixes</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3650"><a href="https://www.bakels.com.au/product-category/slice-mixes-bases/">Slice Mixes &amp; Bases</a></li></ul></li>
+</ul>
+</div></div></div></div></li>
+<li id="menu-item-220" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-220 nav-item dropdown dropdown-mega recipe-category"><a title="Recipes" href="https://www.bakels.com.au/recipes/" data-toggle="dropdown" id="220" aria-haspopup="true" role="button" class="nav-link">Recipes <span class="caret hidden-xs"></span></a>
+<div  class="dropdown-menu "  id="drop-220" aria-labelledby="menu-item-220"><div class="container"><div class="row"><div class="col-3 dropdown-excerpt"><h4>Recipes</h4><p>Our team of applications specialists have developed a wide range of recipes to showcase our versatile products.</p><a href="https://www.bakels.com.au/recipes/" class="btn btn-opaque btn-opaque-orange btn-icon-right btn-fa-angle-right">View all recipes</a></div><div class="col-9 dropdown-content"><ul>
+	<li id="menu-item-21" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-21 nav-item nav-item-col-1"><a title="Bakery" href="https://www.bakels.com.au/recipe-category/bakery/" class="nav-link"><span class="align-middle">Bakery</span></a></li>
+	<li id="menu-item-22" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-22 nav-item nav-item-col-1"><a title="Patisserie" href="https://www.bakels.com.au/recipe-category/patisserie/" class="nav-link"><span class="align-middle">Patisserie</span></a></li>
+</ul>
+</div></div></div></div></li>
+<li id="menu-item-221" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-221 nav-item dropdown dropdown-mega service-pages"><a title="Services" href="https://www.bakels.com.au/services/" data-toggle="dropdown" id="221" aria-haspopup="true" role="button" class="nav-link">Services <span class="caret hidden-xs"></span></a>
+<div  class="dropdown-menu "  id="drop-221" aria-labelledby="menu-item-221"><div class="container"><div class="row"><div class="col-3 dropdown-excerpt"><h4>Services</h4><p>Developing market-leading ingredients with industry-leading facilities, in partnership with customers across the world.</p><a href="https://www.bakels.com.au/services/" class="btn btn-opaque btn-opaque-orange btn-icon-right btn-fa-angle-right">Find out more</a></div><div class="col-9 dropdown-content"><ul>
+	<li id="menu-item-223" class="remove-link services-menu-1 menu-item menu-item-type-custom menu-item-object-custom menu-item-223 nav-item"><div id="custom_html-2" class="widget_text widget-area widget widget_custom_html"><div class="textwidget custom-html-widget"><h4><a href="/services/centres-of-competence/">Centres of Competence</a></h4></div></div><div id="nav_menu-2" class="widget-area widget widget_nav_menu"><div class="menu-services-menu-1-container"><ul id="menu-services-menu-1" class="menu"><li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-229" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-229 nav-item"><a title="Sours" href="/services/centres-of-competence/#sours" class="nav-link">Sours</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-230" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-230 nav-item"><a title="Bread" href="/services/centres-of-competence/#bread" class="nav-link">Bread</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-231" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-231 nav-item"><a title="Sponge Emulsifiers" href="/services/centres-of-competence/#sponge-emulsifiers" class="nav-link">Sponge Emulsifiers</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-232" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-232 nav-item"><a title="Oils &amp; Fats" href="/services/centres-of-competence/#oils-fats" class="nav-link">Oils &#038; Fats</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-233" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-233 nav-item"><a title="Pettinice and Icings" href="/services/centres-of-competence/#pettinice-icings" class="nav-link">Pettinice and Icings</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-234" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-234 nav-item"><a title="Fruit Fillings &amp; Glazes" href="/services/centres-of-competence/#fruit-fillings-glazes" class="nav-link">Fruit Fillings &#038; Glazes</a></li>
+</ul></div></div></li>
+	<li id="menu-item-224" class="remove-link services-menu-2 menu-item menu-item-type-custom menu-item-object-custom menu-item-224 nav-item"><div id="custom_html-3" class="widget_text widget-area widget widget_custom_html"><div class="textwidget custom-html-widget"><h4><a href="/services/baking-centres/switzerland/">Baking Centres</a></h4></div></div><div id="nav_menu-3" class="widget-area widget widget_nav_menu"><div class="menu-services-menu-2-container"><ul id="menu-services-menu-2" class="menu"><li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-3400" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-3400 nav-item"><a title="Switzerland" href="https://www.bakels.com.au/services/baking-centres/switzerland/" class="nav-link">Switzerland</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-3399" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-3399 nav-item"><a title="British Bakels" href="https://www.bakels.com.au/services/baking-centres/british-bakels/" class="nav-link">British Bakels</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-3398" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-3398 nav-item"><a title="Australia" href="https://www.bakels.com.au/services/baking-centres/australia/" class="nav-link">Australia</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-3397" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-3397 nav-item"><a title="Thailand" href="https://www.bakels.com.au/services/baking-centres/thailand/" class="nav-link">Thailand</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-3396" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-3396 nav-item"><a title="Belgium" href="https://www.bakels.com.au/services/baking-centres/belgium/" class="nav-link">Belgium</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-3395" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-3395 nav-item"><a title="Ecuador" href="https://www.bakels.com.au/services/baking-centres/ecuador/" class="nav-link">Ecuador</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-18376" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-18376 nav-item"><a title="Mainland China" href="https://www.bakels.com.au/services/baking-centres/mainland-china/" class="nav-link">Mainland China</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-18372" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-18372 nav-item"><a title="Sweden" href="https://www.bakels.com.au/services/baking-centres/sweden/" class="nav-link">Sweden</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-18375" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-18375 nav-item"><a title="Malaysia" href="https://www.bakels.com.au/services/baking-centres/malaysia/" class="nav-link">Malaysia</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-18373" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-18373 nav-item"><a title="Hong Kong" href="https://www.bakels.com.au/services/baking-centres/hong-kong/" class="nav-link">Hong Kong</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-18374" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-18374 nav-item"><a title="India" href="https://www.bakels.com.au/services/baking-centres/india/" class="nav-link">India</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-18400" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-18400 nav-item"><a title="The Netherlands" href="https://www.bakels.com.au/services/baking-centres/bakels-senior/" class="nav-link">The Netherlands</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-18605" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-18605 nav-item"><a title="Germany" href="https://www.bakels.com.au/services/baking-centres/germany/" class="nav-link">Germany</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-29031" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-29031 nav-item"><a title="Chile" href="https://www.bakels.com.au/services/baking-centres/chile/" class="nav-link">Chile</a></li>
+</ul></div></div></li>
+	<li id="menu-item-225" class="remove-link services-menu-3 menu-item menu-item-type-custom menu-item-object-custom menu-item-225 nav-item"><div id="custom_html-6" class="widget_text widget-area widget widget_custom_html"><div class="textwidget custom-html-widget"><h4><a href="/services/research-development/">Research &amp; Development</a></h4></div></div><div id="nav_menu-4" class="widget-area widget widget_nav_menu"><div class="menu-services-menu-3-container"><ul id="menu-services-menu-3" class="menu"><li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-235" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-235 nav-item"><a title="Foundation To Innovation" href="https://www.bakels.com.au/services/research-development/" class="nav-link">Foundation To Innovation</a></li>
+</ul></div></div></li>
+</ul>
+</div></div></div></div></li>
+<li id="menu-item-222" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-222 nav-item dropdown dropdown-mega about-pages"><a title="About" href="https://www.bakels.com.au/about/" data-toggle="dropdown" id="222" aria-haspopup="true" role="button" class="nav-link">About <span class="caret hidden-xs"></span></a>
+<div  class="dropdown-menu "  id="drop-222" aria-labelledby="menu-item-222"><div class="container"><div class="row"><div class="col-3 dropdown-excerpt"><h4>About</h4><p>Our commitment goes beyond the ingredients we produce - Our rich history of research and development and innovation breeds our continuous investment in people and customer partnerships.</p><a href="https://www.bakels.com.au/about/" class="btn btn-opaque btn-opaque-orange btn-icon-right btn-fa-angle-right">Find out more</a></div><div class="col-9 dropdown-content"><ul>
+	<li id="menu-item-226" class="remove-link about-menu-1 menu-item menu-item-type-custom menu-item-object-custom menu-item-226 nav-item"><div id="nav_menu-5" class="widget-area widget widget_nav_menu"><h4 class="widget-title">About Bakels</h4><div class="menu-about-menu-1-container"><ul id="menu-about-menu-1" class="menu"><li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-258" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-258 nav-item"><a title="Our Customers" href="https://www.bakels.com.au/about/our-customers/" class="nav-link">Our Customers</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-257" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-257 nav-item"><a title="Mission Statement" href="https://www.bakels.com.au/about/mission-statement/" class="nav-link">Mission Statement</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-256" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-256 nav-item"><a title="Core Values" href="https://www.bakels.com.au/about/core-values/" class="nav-link">Core Values</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-3598" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3598 nav-item"><a title="Australian Bakels" href="https://www.bakels.com.au/local/" class="nav-link">Australian Bakels</a></li>
+</ul></div></div></li>
+	<li id="menu-item-227" class="remove-link about-menu-2 menu-item menu-item-type-custom menu-item-object-custom menu-item-227 nav-item"><div id="nav_menu-6" class="widget-area widget widget_nav_menu"><h4 class="widget-title">&nbsp;</h4><div class="menu-about-menu-2-container"><ul id="menu-about-menu-2" class="menu"><li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-261" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-261 nav-item"><a title="History" href="https://www.bakels.com.au/about/history/" class="nav-link">History</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-260" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-260 nav-item"><a title="Facts &amp; Figures" href="https://www.bakels.com.au/about/facts-figures/" class="nav-link">Facts &#038; Figures</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-262" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-262 nav-item"><a title="Jobs" href="https://www.bakels.com.au/about/jobs/" class="nav-link">Jobs</a></li>
+</ul></div></div></li>
+	<li id="menu-item-228" class="remove-link about-menu-3 menu-item menu-item-type-custom menu-item-object-custom menu-item-228 nav-item"></li>
+</ul>
+</div></div></div></div></li>
+</ul>					</div>
+				</nav>
+			</div>
+		</div>
+	</div>
+</header>
+
+<div class="site-breadcrumb breadcrumbs" typeof="BreadcrumbList" vocab="https://schema.org/">
+  <div class="container">
+    <div class="row">
+      <div class="col-12">
+      	<ul>
+        	<!-- Breadcrumb NavXT 7.3.0 -->
+<li><a property="item" typeof="WebPage" title="Go to Australian Bakels." href="https://www.bakels.com.au" class="home"><span property="name">Home</span></a><meta property="position" content="1"></li><li><i class="fa fa-angle-right"></i></li><li><a property="item" typeof="WebPage" title="Go to Recipes." href="https://www.bakels.com.au/recipes/" class="recipes-root post post-recipes"><span property="name">Recipes</span></a></li><li><i class="fa fa-angle-right"></i></li><li><span property="name">Plant-Based Burger Patty (Using Bakels Plant-Based Savoury Mix)</span></li>    	</ul>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="site-inner">
+
+    
+        	<div class="content-header curve-section">
+	    <div class="container">
+	        <div class="row">
+	            <div class="col-12 text-xs-center">
+	
+        <div class="content-sidebar-wrap">
+
+            <main class="content">
+    <article class="post-17953 recipes type-recipes status-publish hentry finished-product-filling finished-product-meat-pie finished-product-sausage-roll finished-product-savoury-good" itemscope="" itemtype="https://schema.org/CreativeWork">
+
+        <h1>Plant-Based Burger Patty (Using Bakels Plant-Based Savoury Mix)</h1>
+        
+    </article>
+</main>
+
+        </div>
+
+        		        </div>
+	        </div>
+	    </div>
+	</div>
+	                <div class="social-section" id="next-section">
+            <div class="container">
+                <div class="row">
+                    <div class="col-lg-4 col-md-4 col-sm-12 col-12 text-xs-left">
+                                                <a href="https://www.bakels.com.au/recipes/" class="btn btn-blank btn-icon-left btn-fa-angle-left">Back to recipes</a>
+                    </div>
+                    <div class="col-lg-8 col-md-8 col-sm-12 col-12 text-md-right text-xs-center d-md-block d-none">
+                        <div class="d-md-inline-block d-none"><div class="favourites"><a href="https://www.bakels.com.au/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-17953"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div></div>
+                                                <div class="d-inline-block social-btn social-inline">
+
+                                                            <a class="social-share btn-fa-facebook-f" href="javascript:void(0);" id="fb-share" rel="nofollow"><span class="social-tooltip">Share on Facebook</span></a>
+                            
+                            <a class="social-share btn-fa-twitter-x" href="javascript:void(0);" id="tweet" rel="nofollow"><i class=""><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Pro 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc.--><path fill="currentColor" stroke="currentColor" d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8l164.9-188.5L26.8 48h145.6l100.5 132.9L389.2 48zm-24.8 373.8h39.1L151.1 88h-42l255.3 333.8z"/></svg></i><span class="social-tooltip">Tweet this Page</span></a>
+                            <a class="social-share btn-fa-linkedin-in" href="javascript:void(0);" id="linkedin" rel="nofollow"><span class="social-tooltip">Share on Linkedin</span></a>
+                            <a class="social-share btn-fa-whatsapp d-md-none d-inline-block" href="javascript:void(0);" id="whatsapp" rel="nofollow"><span class="social-tooltip">Share on WhatsApp</span></a>
+                        </div>
+                                                                            <div class="d-inline-block social-btn social-inline social-btn-download">
+                            <a href="https://www.bakels.com.au/recipes/plant-based-burger-patty-using-bakels-plant-based-savoury-mix/pdf/" class="btn btn-opaque btn-opaque-blue btn-icon-right btn-download" download><span class="social-tooltip">Download PDF</span></a>
+                        </div>
+                                                <div class="d-inline-block social-btn social-inline social-btn-preview">
+                            <input type="text" value="https://www.bakels.com.au/recipes/plant-based-burger-patty-using-bakels-plant-based-savoury-mix/" readonly id="clipboard" class="sr-only" tabindex='-1' aria-hidden='true'>
+                            <button onclick="copyClipboard()" class="btn btn-opaque btn-opaque-blue btn-icon-right btn-preview" title="Copy to clipboard"><span class="social-tooltip">Copy to clipboard</span></button>
+                        </div>
+                                                <div class="d-inline-block social-btn">
+                            <a href="mailto:?subject=Check out Plant-Based Burger Patty (Using Bakels Plant-Based Savoury Mix) on Bakels.com&body=https://www.bakels.com.au/recipes/plant-based-burger-patty-using-bakels-plant-based-savoury-mix/" class="btn btn-opaque btn-opaque-blue btn-icon-right btn-envelop"><span class="social-tooltip">Email this page</span></a>                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                <div class="recipe-content">
+            <div class="container">
+                <div class="row">
+
+                    <div class="col-lg-12">
+                            <div class="recipe-details-section">
+        <div class="row">
+            <div class="col-12 recipe-details-accordion">
+                                                                                <div class="row recipe-tab-accordion-row">
+                            <div class="col-lg-6 col-md-12 col-sm-12 col-12 mb-order-2">
+                                <div class="accordion card-filter single-recipe" id="">
+                                                                                                                    <div class="card">
+                                            <div class="card-header" id="card-ingredients_1">
+                                                                                                <a href="javascript:void(0);" data-toggle="collapse" data-target="#tab-ingredients_1" aria-expanded="false" aria-controls="collapseOne">
+                                                    Ingredients                                                </a>
+                                            </div>
+
+                                            <div id="tab-ingredients_1" class="collapse show" aria-labelledby="card-ingredients_1" data-parent="">
+                                                <div class="card-body">
+                                                                            <div class="row row-group">
+                <div class="col-12 text-xs-left"><span class="group-label">Group 1</span></div>
+                <div class="col-lg-8 col-md-8 col-sm-8 col-8 text-xs-left">
+                    <span class="sr-only ingredient-label">Ingredient</span>
+                </div>
+
+                                    <div class="col-lg-4 col-md-4 col-sm-4 col-4 text-xs-right">
+                        <span class="ingredient-label">KG</span>
+                    </div>
+                
+                                        <div class="col-lg-8 col-md-8 col-sm-8 col-8 text-xs-left">Bakels Plant-Based Savoury Mix</div>
+                    
+                                            <div class="col-lg-4 col-md-4 col-sm-4 col-4 text-xs-right">1.000</div>
+                    
+                                            <div class="col-lg-8 col-md-8 col-sm-8 col-8 text-xs-left">Vital Wheat Gluten</div>
+                    
+                                            <div class="col-lg-4 col-md-4 col-sm-4 col-4 text-xs-right">0.040</div>
+                    
+                                </div>
+            <div class="row row-group">
+                                    <div class="col-12 text-xs-right">
+                        <strong>Total Weight</strong>: 1.040                    </div>
+                
+                            </div>
+                                <div class="row row-group">
+                <div class="col-12 text-xs-left"><span class="group-label">Group 2</span></div>
+                <div class="col-lg-8 col-md-8 col-sm-8 col-8 text-xs-left">
+                    <span class="sr-only ingredient-label">Ingredient</span>
+                </div>
+
+                                    <div class="col-lg-4 col-md-4 col-sm-4 col-4 text-xs-right">
+                        <span class="ingredient-label">KG</span>
+                    </div>
+                
+                                        <div class="col-lg-8 col-md-8 col-sm-8 col-8 text-xs-left">Molasses (optional)</div>
+                    
+                                            <div class="col-lg-4 col-md-4 col-sm-4 col-4 text-xs-right">0.010</div>
+                    
+                                            <div class="col-lg-8 col-md-8 col-sm-8 col-8 text-xs-left">Vegetable Oil</div>
+                    
+                                            <div class="col-lg-4 col-md-4 col-sm-4 col-4 text-xs-right">0.100</div>
+                    
+                                            <div class="col-lg-8 col-md-8 col-sm-8 col-8 text-xs-left">Water (ambient)</div>
+                    
+                                            <div class="col-lg-4 col-md-4 col-sm-4 col-4 text-xs-right">1.200</div>
+                    
+                                </div>
+            <div class="row row-group">
+                                    <div class="col-12 text-xs-right">
+                        <strong>Total Weight</strong>: 1.310                    </div>
+                
+                            </div>
+                                                                        </div>
+                                            </div>
+                                        </div>
+                                    
+                                                                                                                    <div class="card">
+                                            <div class="card-header" id="card-method_1">
+                                                <a href="javascript:void(0);" data-toggle="collapse" data-target="#tab-method_1" aria-expanded="false" aria-controls="collapseOne">
+                                                    Method                                                </a>
+                                            </div>
+
+                                            <div id="tab-method_1" class="collapse " aria-labelledby="card-method_1" data-parent="">
+                                                <div class="card-body">
+                                                    <p>1. Dry blend Group 1 in mixing bowl.<br />
+2. Add Group 2 into mixing bowl.<br />
+3. Blend together on low speed for 5 minutes. Scrape down in between mixing.<br />
+4. Let the mix stand for 5-10 minutes for full hydration.</p>
+<p><em><span style="text-decoration: underline">Cooking Procedure:</span></em><br />
+Divide the filling into desired portions and place on oiled surface to prevent sticking.<br />
+Shape each portion into desired patty shape. Patty should be thinner in the middle to prevent edges from breaking during frying/grilling<br />
+Fry/grill at low flame as the patties are prone to over-browning.<br />
+Cooking time for each side is approximately 4-5 minute for 160g patty with 10cm diameter.<br />
+Let cooked patties cool down to rest and serve warm.</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    
+                                    
+                                                                                                                    <div class="card">
+                                            <div class="card-header" id="card-related_1">
+                                                <a href="javascript:void(0);" data-toggle="collapse" data-target="#tab-related_1" aria-expanded="false" aria-controls="collapseOne">
+                                                    Product Used                                                </a>
+                                            </div>
+
+                                            <div id="tab-related_1" class="collapse " aria-labelledby="card-related_1" data-parent="">
+                                                <div class="card-body">
+                                                            <ul class="related-list">
+                </ul>
+                                                    </div>
+                                            </div>
+                                        </div>
+                                                                    </div>
+                            </div>
+                                                            <div class="col-lg-6 col-md-12 col-sm-12 col-12 mb-order-1">
+                                        <div class="image-slider" id="gallery-slider">
+                    <div>
+                <div class="overview-item">
+                    <img width="560" height="370" src="https://www.bakels.com.au/wp-content/uploads/sites/21/2020/08/Vegan-Burger-Patty-560x370.jpg" class="attachment-content-carousel-thumb-3 size-content-carousel-thumb-3 wp-post-image" alt="Plant-Based Burger Patty" decoding="async" srcset="https://www.bakels.com.au/wp-content/uploads/sites/21/2020/08/Vegan-Burger-Patty-560x370.jpg 560w, https://www.bakels.com.au/wp-content/uploads/sites/21/2020/08/Vegan-Burger-Patty-160x107.jpg 160w" sizes="(max-width: 560px) 100vw, 560px" />                                    </div>
+            </div>
+        
+            </div>
+    
+                                    </div>
+                                                    </div>
+                                                </div>
+        </div>
+    </div>
+                    </div>
+
+                                        <div class="col-lg-6 col-md-12 col-sm-12 col-12 d-lg-none d-block">
+                                            </div>
+                    
+                    <div class="col-lg-6 col-md-12 col-sm-12 col-12 print-display">
+                                            </div>
+
+                                        <div class="col-lg-6 col-md-12 col-sm-12 col-12 d-lg-block d-none">
+                                            </div>
+                    
+                </div>
+            </div>
+        </div>
+            <div class="social-section d-md-none d-block">
+            <div class="container">
+                <div class="row">
+                    <div class="col-lg-8 col-md-8 col-sm-12 col-12 text-md-right text-xs-center">
+                        <div class="d-inline-block"><div class="favourites"><a href="https://www.bakels.com.au/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-17953"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div></div>
+                                                <div class="d-inline-block social-btn social-inline social-inline">
+                            <a class="social-share btn-fa-facebook-f" href="javascript:void(0);" id="fb-share" rel="nofollow" title="Share on Facebook">Facebook</a>
+                            <a class="social-share btn-fa-twitter" href="javascript:void(0);" id="tweet" rel="nofollow" title="Tweet this Page">Twitter</a>
+                            <a class="social-share btn-fa-linkedin-in" href="javascript:void(0);" id="linkedin" rel="nofollow" title="Share on Linkedin">LinkedIn</a>
+                            <a class="social-share btn-fa-whatsapp d-md-none d-inline-block" href="javascript:void(0);" id="whatsapp" rel="nofollow"><span class="social-tooltip" title="Share on WhatsApp">WhatsApp</a>
+                        </div>
+                                                                            <div class="d-inline-block social-btn social-inline social-btn-download">
+                            <a href="https://www.bakels.com.au/recipes/plant-based-burger-patty-using-bakels-plant-based-savoury-mix/pdf/" class="btn btn-opaque btn-opaque-blue btn-icon-right btn-download" download title="Download PDF">Download PDF</a>
+                        </div>
+                        <div class="d-inline-block social-btn social-inline social-btn-preview">
+                            <input type="text" value="https://www.bakels.com.au/recipes/plant-based-burger-patty-using-bakels-plant-based-savoury-mix/" readonly id="clipboard-mobile" class="sr-only" tabindex='-1' aria-hidden='true'>
+                            <button onclick="copyClipboardMobile()" class="btn btn-opaque btn-opaque-blue btn-icon-right btn-preview" title="Copy to clipboard"><span class="social-tooltip">Copy to clipboard</span></button>
+                        </div>
+                                                                        <div class="d-inline-block social-btn">
+                            <a href="mailto:?subject=Check out Plant-Based Burger Patty (Using Bakels Plant-Based Savoury Mix) on Bakels.com&body=https://www.bakels.com.au/recipes/plant-based-burger-patty-using-bakels-plant-based-savoury-mix/" class="btn btn-opaque btn-opaque-blue btn-icon-right btn-envelop">Email</a>                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="recipe-term-section">
+            <div class="container">
+                <div class="row">
+                    
+                    
+                    
+                                        <div class="col-lg-3 col-md-3 col-sm-6 col-6 text-xs-center term-item">
+                        <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/icon-finished-product-new.svg"alt="Finished Product">
+                        <h4>Finished Product</h4>
+                        <p><a href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4167">Filling</a>, <a href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4176">Meat Pie</a>, <a href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1832">Sausage Roll</a>, <a href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1833">Savoury Good</a></p>
+                    </div>
+                                    </div>
+            </div>
+        </div>
+            <div class="related-category-section" id="related-recipe">
+            <div class="container">
+                <div class="row">
+                    <div class="col-12 text-xs-center">
+                        <h2>Related recipes</h2>
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-12">
+                        <div class="related-category-slider" id="related-recipe-slider">
+                        <div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.bakels.com.au/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-17328"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.bakels.com.au/recipes/apple-and-blueberry-flan-filling-no-cook-method-using-pettina-apple-and-blueberry-mix/" title="Apple and Blueberry Flan Filling &#8211; No Cook Method (Using Pettina Apple and Blueberry Mix)">
+                <img width="312" height="240" src="https://www.bakels.com.au/wp-content/uploads/sites/21/2019/05/Apple-Filling-312x240.jpg" class="aligncenter wp-post-image" alt="Apple and Blueberry Flan Filling &#8211; No Cook Method (Using Pettina Apple and Blueberry Mix)" decoding="async" />            </a>
+                <h4>
+        	<a href="https://www.bakels.com.au/recipes/apple-and-blueberry-flan-filling-no-cook-method-using-pettina-apple-and-blueberry-mix/">Apple and Blueberry Flan Filling &#8211; No Cook Method (Using Pettina Apple and Blueberry Mix)</a>
+        </h4>
+        <p><a href="https://www.bakels.com.au/recipe-category/bakery/">Bakery</a>, <a href="https://www.bakels.com.au/recipe-category/patisserie/">Patisserie</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.bakels.com.au/recipes/apple-and-blueberry-flan-filling-no-cook-method-using-pettina-apple-and-blueberry-mix/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">1 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.bakels.com.au/products/pettina-apple-and-blueberry-mix/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Pettina Apple and Blueberry Mix</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.bakels.com.au/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-15735"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.bakels.com.au/recipes/apple-cinnamon-filling/" title="Apple Cinnamon Filling">
+                <img width="312" height="240" src="https://www.bakels.com.au/wp-content/uploads/sites/21/2019/05/Apple-Filling-312x240.jpg" class="aligncenter wp-post-image" alt="Apple Cinnamon Filling" decoding="async" />            </a>
+                <h4>
+        	<a href="https://www.bakels.com.au/recipes/apple-cinnamon-filling/">Apple Cinnamon Filling</a>
+        </h4>
+        <p><a href="https://www.bakels.com.au/recipe-category/bakery/">Bakery</a>, <a href="https://www.bakels.com.au/recipe-category/patisserie/">Patisserie</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.bakels.com.au/recipes/apple-cinnamon-filling/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">1 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.bakels.com.au/products/bakels-instant-starch/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Bakels Instant Starch</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.bakels.com.au/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-17326"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.bakels.com.au/recipes/apple-filling-using-pettina-apple-mix/" title="Apple Filling (Using Pettina Apple Mix)">
+                <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/BAKELS-HAT-1140x740.jpg" alt="Apple Filling (Using Pettina Apple Mix)" class="aligncenter">
+            </a>
+                <h4>
+        	<a href="https://www.bakels.com.au/recipes/apple-filling-using-pettina-apple-mix/">Apple Filling (Using Pettina Apple Mix)</a>
+        </h4>
+        <p><a href="https://www.bakels.com.au/recipe-category/bakery/">Bakery</a>, <a href="https://www.bakels.com.au/recipe-category/patisserie/">Patisserie</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.bakels.com.au/recipes/apple-filling-using-pettina-apple-mix/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.bakels.com.au/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-16872"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.bakels.com.au/recipes/apple-pie-filling-using-bakels-instant-starch/" title="Apple Pie Filling &#8211; No Cook Method (Using Bakels Instant Starch)">
+                <img width="312" height="240" src="https://www.bakels.com.au/wp-content/uploads/sites/21/2019/05/Apple-Filling-312x240.jpg" class="aligncenter wp-post-image" alt="Apple Pie Filling &#8211; No Cook Method (Using Bakels Instant Starch)" decoding="async" />            </a>
+                <h4>
+        	<a href="https://www.bakels.com.au/recipes/apple-pie-filling-using-bakels-instant-starch/">Apple Pie Filling &#8211; No Cook Method (Using Bakels Instant Starch)</a>
+        </h4>
+        <p><a href="https://www.bakels.com.au/recipe-category/bakery/">Bakery</a>, <a href="https://www.bakels.com.au/recipe-category/patisserie/">Patisserie</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.bakels.com.au/recipes/apple-pie-filling-using-bakels-instant-starch/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">1 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.bakels.com.au/products/bakels-instant-starch/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Bakels Instant Starch</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.bakels.com.au/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-17214"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.bakels.com.au/recipes/beef-and-burgundy-pie-filling-using-bakels-cook-up-starch/" title="Beef and Burgundy Pie Filling (Using Bakels Cook Up Starch)">
+                <img width="300" height="240" src="https://www.bakels.com.au/wp-content/uploads/sites/21/2019/05/Meat-Pie-Filling-300x240.jpg" class="aligncenter wp-post-image" alt="Beef and Burgundy Pie Filling (Using Bakels Cook Up Starch)" decoding="async" />            </a>
+                <h4>
+        	<a href="https://www.bakels.com.au/recipes/beef-and-burgundy-pie-filling-using-bakels-cook-up-starch/">Beef and Burgundy Pie Filling (Using Bakels Cook Up Starch)</a>
+        </h4>
+        <p><a href="https://www.bakels.com.au/recipe-category/bakery/">Bakery</a>, <a href="https://www.bakels.com.au/recipe-category/patisserie/">Patisserie</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.bakels.com.au/recipes/beef-and-burgundy-pie-filling-using-bakels-cook-up-starch/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">2 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.bakels.com.au/products/bakels-cook-up-starch/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Bakels Cook Up Starch</a>
+										</li>
+																		<li>
+												<a href="https://www.bakels.com.au/products/fino-meat-pie-seasoning/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Fino Meat Pie Seasoning</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.bakels.com.au/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-16810"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.bakels.com.au/recipes/blackberry-or-loganberry-pie-filling-using-bakels-instant-starch/" title="Blackberry or Loganberry Pie Filling (Using Bakels Instant Starch)">
+                <img width="360" height="240" src="https://www.bakels.com.au/wp-content/uploads/sites/21/2020/02/Blackberry-360x240.jpg" class="aligncenter wp-post-image" alt="Blackberry or Loganberry Pie Filling (Using Bakels Instant Starch)" decoding="async" />            </a>
+                <h4>
+        	<a href="https://www.bakels.com.au/recipes/blackberry-or-loganberry-pie-filling-using-bakels-instant-starch/">Blackberry or Loganberry Pie Filling (Using Bakels Instant Starch)</a>
+        </h4>
+        <p><a href="https://www.bakels.com.au/recipe-category/bakery/">Bakery</a>, <a href="https://www.bakels.com.au/recipe-category/patisserie/">Patisserie</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.bakels.com.au/recipes/blackberry-or-loganberry-pie-filling-using-bakels-instant-starch/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">1 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.bakels.com.au/products/bakels-instant-starch/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Bakels Instant Starch</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.bakels.com.au/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-16779"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.bakels.com.au/recipes/butterscotch-filling-using-cake-margarine-medium-grade/" title="Butterscotch Filling (Using Cake Margarine &#8211; Medium Grade)">
+                <img width="360" height="240" src="https://www.bakels.com.au/wp-content/uploads/sites/21/2020/02/Butterscotch-Filling-e1585190107627-360x240.jpg" class="aligncenter wp-post-image" alt="Butterscotch Filling (Using Cake Margarine &#8211; Medium Grade)" decoding="async" />            </a>
+                <h4>
+        	<a href="https://www.bakels.com.au/recipes/butterscotch-filling-using-cake-margarine-medium-grade/">Butterscotch Filling (Using Cake Margarine &#8211; Medium Grade)</a>
+        </h4>
+        <p><a href="https://www.bakels.com.au/recipe-category/bakery/">Bakery</a>, <a href="https://www.bakels.com.au/recipe-category/patisserie/">Patisserie</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.bakels.com.au/recipes/butterscotch-filling-using-cake-margarine-medium-grade/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">1 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.bakels.com.au/products/cake-margarine-medium/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Cake Margarine Medium</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.bakels.com.au/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-17324"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.bakels.com.au/recipes/cappuccino-coffee-filling-using-pettina-fond-suisse/" title="Cappuccino Coffee Filling (Using Pettina Fond Suisse)">
+                <img width="360" height="240" src="https://www.bakels.com.au/wp-content/uploads/sites/21/2018/06/CARAMEL-3-360x240.jpg" class="aligncenter wp-post-image" alt="Cappuccino Coffee Filling (Using Pettina Fond Suisse)" decoding="async" />            </a>
+                <h4>
+        	<a href="https://www.bakels.com.au/recipes/cappuccino-coffee-filling-using-pettina-fond-suisse/">Cappuccino Coffee Filling (Using Pettina Fond Suisse)</a>
+        </h4>
+        <p><a href="https://www.bakels.com.au/recipe-category/bakery/">Bakery</a>, <a href="https://www.bakels.com.au/recipe-category/patisserie/">Patisserie</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.bakels.com.au/recipes/cappuccino-coffee-filling-using-pettina-fond-suisse/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">1 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.bakels.com.au/products/pettina-fond-suisse/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Pettina Fond Suisse</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.bakels.com.au/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-17236"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.bakels.com.au/recipes/cheese-and-tomato-pie-filling-using-bakels-cook-up-starch/" title="Cheese and Tomato Pie Filling (Using Bakels Cook Up Starch)">
+                <img width="317" height="240" src="https://www.bakels.com.au/wp-content/uploads/sites/21/2020/03/Steak-and-mushroom-pie-317x240.jpg" class="aligncenter wp-post-image" alt="Cheese and Tomato Pie Filling (Using Bakels Cook Up Starch)" decoding="async" />            </a>
+                <h4>
+        	<a href="https://www.bakels.com.au/recipes/cheese-and-tomato-pie-filling-using-bakels-cook-up-starch/">Cheese and Tomato Pie Filling (Using Bakels Cook Up Starch)</a>
+        </h4>
+        <p><a href="https://www.bakels.com.au/recipe-category/bakery/">Bakery</a>, <a href="https://www.bakels.com.au/recipe-category/patisserie/">Patisserie</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.bakels.com.au/recipes/cheese-and-tomato-pie-filling-using-bakels-cook-up-starch/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">2 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.bakels.com.au/products/bakels-cook-up-starch/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Bakels Cook Up Starch</a>
+										</li>
+																		<li>
+												<a href="https://www.bakels.com.au/products/fino-meat-pie-seasoning/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Fino Meat Pie Seasoning</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.bakels.com.au/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-17297"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.bakels.com.au/recipes/cheese-custard-fruit-filling-using-bakels-gourmet-cheesecake-mix/" title="Cheese Custard Fruit Filling (Using Bakels Gourmet Cheesecake Mix)">
+                <img width="360" height="240" src="https://www.bakels.com.au/wp-content/uploads/sites/21/2020/03/Gourmet-Cheesecake-360x240.jpg" class="aligncenter wp-post-image" alt="Cheese Custard Fruit Filling (Using Bakels Gourmet Cheesecake Mix)" decoding="async" />            </a>
+                <h4>
+        	<a href="https://www.bakels.com.au/recipes/cheese-custard-fruit-filling-using-bakels-gourmet-cheesecake-mix/">Cheese Custard Fruit Filling (Using Bakels Gourmet Cheesecake Mix)</a>
+        </h4>
+        <p><a href="https://www.bakels.com.au/recipe-category/bakery/">Bakery</a>, <a href="https://www.bakels.com.au/recipe-category/patisserie/">Patisserie</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.bakels.com.au/recipes/cheese-custard-fruit-filling-using-bakels-gourmet-cheesecake-mix/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">2 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.bakels.com.au/products/bakels-gourmet-cheesecake-mix-mb/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Bakels Gourmet Cheesecake Mix MB</a>
+										</li>
+																		<li>
+												<a href="https://www.bakels.com.au/products/bakels-instant-custard-mix/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Bakels Instant Custard Mix</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.bakels.com.au/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-17357"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.bakels.com.au/recipes/cheese-custard-fruit-filling-using-pettina-cheesecake-mix/" title="Cheese Custard Fruit Filling (Using Pettina Cheesecake Mix)">
+                <img width="360" height="240" src="https://www.bakels.com.au/wp-content/uploads/sites/21/2020/03/Cheese-Custard-Fruit-Fillings-360x240.jpg" class="aligncenter wp-post-image" alt="Cheese Custard Fruit Filling (Using Pettina Cheesecake Mix)" decoding="async" />            </a>
+                <h4>
+        	<a href="https://www.bakels.com.au/recipes/cheese-custard-fruit-filling-using-pettina-cheesecake-mix/">Cheese Custard Fruit Filling (Using Pettina Cheesecake Mix)</a>
+        </h4>
+        <p><a href="https://www.bakels.com.au/recipe-category/bakery/">Bakery</a>, <a href="https://www.bakels.com.au/recipe-category/patisserie/">Patisserie</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.bakels.com.au/recipes/cheese-custard-fruit-filling-using-pettina-cheesecake-mix/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">1 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.bakels.com.au/products/pettina-cheesecake-mix/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Pettina Cheesecake Mix</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.bakels.com.au/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-17213"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.bakels.com.au/recipes/chicken-and-leek-pie-filling-using-bakels-cook-up-starch/" title="Chicken and Leek Pie Filling (Using Bakels Cook Up Starch)">
+                <img width="360" height="240" src="https://www.bakels.com.au/wp-content/uploads/sites/21/2019/05/chicken-Pie-filling-360x240.jpg" class="aligncenter wp-post-image" alt="Chicken and Leek Pie Filling (Using Bakels Cook Up Starch)" decoding="async" />            </a>
+                <h4>
+        	<a href="https://www.bakels.com.au/recipes/chicken-and-leek-pie-filling-using-bakels-cook-up-starch/">Chicken and Leek Pie Filling (Using Bakels Cook Up Starch)</a>
+        </h4>
+        <p><a href="https://www.bakels.com.au/recipe-category/bakery/">Bakery</a>, <a href="https://www.bakels.com.au/recipe-category/patisserie/">Patisserie</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.bakels.com.au/recipes/chicken-and-leek-pie-filling-using-bakels-cook-up-starch/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">2 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.bakels.com.au/products/bakels-cook-up-starch/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Bakels Cook Up Starch</a>
+										</li>
+																		<li>
+												<a href="https://www.bakels.com.au/products/fino-meat-pie-seasoning/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Fino Meat Pie Seasoning</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.bakels.com.au/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-15737"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.bakels.com.au/recipes/chicken-pie-filling/" title="Chicken Pie Filling">
+                <img width="360" height="240" src="https://www.bakels.com.au/wp-content/uploads/sites/21/2019/05/chicken-Pie-filling-360x240.jpg" class="aligncenter wp-post-image" alt="Chicken Pie Filling" decoding="async" />            </a>
+                <h4>
+        	<a href="https://www.bakels.com.au/recipes/chicken-pie-filling/">Chicken Pie Filling</a>
+        </h4>
+        <p><a href="https://www.bakels.com.au/recipe-category/bakery/">Bakery</a>, <a href="https://www.bakels.com.au/recipe-category/patisserie/">Patisserie</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.bakels.com.au/recipes/chicken-pie-filling/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">1 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.bakels.com.au/products/fino-meat-pie-seasoning/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Fino Meat Pie Seasoning</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.bakels.com.au/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-17313"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.bakels.com.au/recipes/continental-filling-cream-using-pettina-fond-suisse/" title="Continental Filling Cream (Using Pettina Fond Suisse)">
+                <img width="360" height="240" src="https://www.bakels.com.au/wp-content/uploads/sites/21/2018/10/BakelsCream-344-Large-360x240.jpg" class="aligncenter wp-post-image" alt="Continental Filling Cream (Using Pettina Fond Suisse)" decoding="async" srcset="https://www.bakels.com.au/wp-content/uploads/sites/21/2018/10/BakelsCream-344-Large-360x240.jpg 360w, https://www.bakels.com.au/wp-content/uploads/sites/21/2018/10/BakelsCream-344-Large-300x200.jpg 300w, https://www.bakels.com.au/wp-content/uploads/sites/21/2018/10/BakelsCream-344-Large-768x512.jpg 768w, https://www.bakels.com.au/wp-content/uploads/sites/21/2018/10/BakelsCream-344-Large-1024x683.jpg 1024w, https://www.bakels.com.au/wp-content/uploads/sites/21/2018/10/BakelsCream-344-Large.jpg 1620w" sizes="(max-width: 360px) 100vw, 360px" />            </a>
+                <h4>
+        	<a href="https://www.bakels.com.au/recipes/continental-filling-cream-using-pettina-fond-suisse/">Continental Filling Cream (Using Pettina Fond Suisse)</a>
+        </h4>
+        <p><a href="https://www.bakels.com.au/recipe-category/bakery/">Bakery</a>, <a href="https://www.bakels.com.au/recipe-category/patisserie/">Patisserie</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.bakels.com.au/recipes/continental-filling-cream-using-pettina-fond-suisse/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">1 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.bakels.com.au/products/pettina-fond-suisse/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Pettina Fond Suisse</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.bakels.com.au/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-17315"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.bakels.com.au/recipes/continental-yogurt-filling-using-pettina-fond-suisse/" title="Continental Yogurt Filling (Using Pettina Fond Suisse)">
+                <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/BAKELS-HAT-1140x740.jpg" alt="Continental Yogurt Filling (Using Pettina Fond Suisse)" class="aligncenter">
+            </a>
+                <h4>
+        	<a href="https://www.bakels.com.au/recipes/continental-yogurt-filling-using-pettina-fond-suisse/">Continental Yogurt Filling (Using Pettina Fond Suisse)</a>
+        </h4>
+        <p><a href="https://www.bakels.com.au/recipe-category/bakery/">Bakery</a>, <a href="https://www.bakels.com.au/recipe-category/patisserie/">Patisserie</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.bakels.com.au/recipes/continental-yogurt-filling-using-pettina-fond-suisse/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+                        </div>
+        </div>
+  	</div>
+</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        
+    
+    </div>
+
+
+    	          
+  <div class="footer-curve"></div>
+
+  <div class="footer-area">
+    <div class="footer-search">
+      <div class="container">
+        <div class="row">
+          <div class="col-lg-8 col-md-7 col-sm-10 col-10 text-xs-center">
+
+            
+            
+              <div class="footer-social">
+                <ul>
+                                                            <li>
+                        <a href="https://www.facebook.com/AustralianBakels/" title="Facebook" target="_blank" class="fa fa-facebook"><span>Facebook</span></a>
+                      </li>
+                                      
+                  
+                  
+                                      <li>
+                      <a href="https://instagram.com/bakelsau" title="Instagram" target="_blank" class="fa fa-instagram"><span>Instagram</span></a>
+                    </li>
+                  
+                                      <li>
+                      <a href="https://linkedin.com/company/australian-bakels-01" title="Linkedin" target="_blank" class="fa fa-linkedin"><span>Linkedin</span></a>
+                    </li>
+                  
+                  
+                  
+                  
+                                      <li>
+                                            <a href="https://www.bakels.com.au/email-newsletter/" title="Newsletter" target="_blank" class="fa fa-envelope"><span>Newsletter</span></a>
+                    </li>
+                                  </ul>
+              </div>
+            
+          </div>
+          <div class="col-lg-4 col-md-5 col-sm-2 col-2 text-sm-right text-xs-center">
+            <div class="scroll-to-top">
+              <span class="d-md-inline-block d-none scroll-text">Back to top</span>
+              <button class="btn btn-scroll">Back to top</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="footer-widgets">
+      <div class="container">
+        <div class="row">
+                        <div class="col-lg-2 col-md-4 col-12 footer-widget footer-widget-1">
+                <div id="nav_menu-7" class="widget-area widget widget_nav_menu"><h4 class="widget-title">Navigation</h4><div class="menu-footer-1-container"><ul id="menu-footer-1" class="menu"><li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-239" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-home menu-item-239 nav-item"><a title="Home" href="https://www.bakels.com.au/" class="nav-link">Home</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-242" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-242 nav-item"><a title="Jobs at Bakels" href="https://www.bakels.com.au/about/jobs/" class="nav-link">Jobs at Bakels</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-241" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-241 nav-item"><a title="Contact" href="https://www.bakels.com.au/contact/" class="nav-link">Contact</a></li>
+</ul></div></div>            </div>
+            
+                        <div class="col-lg-2 col-md-4 col-12 footer-widget footer-widget-2">
+                <div id="nav_menu-8" class="widget-area widget widget_nav_menu"><h4 class="widget-title">About</h4><div class="menu-footer-2-container"><ul id="menu-footer-2" class="menu"><li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-247" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-247 nav-item"><a title="Our Customers" href="https://www.bakels.com.au/about/our-customers/" class="nav-link">Our Customers</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-246" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-246 nav-item"><a title="Mission Statement" href="https://www.bakels.com.au/about/mission-statement/" class="nav-link">Mission Statement</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-243" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-243 nav-item"><a title="Core Values" href="https://www.bakels.com.au/about/core-values/" class="nav-link">Core Values</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-245" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-245 nav-item"><a title="History" href="https://www.bakels.com.au/about/history/" class="nav-link">History</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-244" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-244 nav-item"><a title="Facts &amp; Figures" href="https://www.bakels.com.au/about/facts-figures/" class="nav-link">Facts &#038; Figures</a></li>
+</ul></div></div>            </div>
+            
+                        <div class="col-lg-3 col-md-4 col-12 footer-widget footer-widget-3">
+                <div id="nav_menu-9" class="widget-area widget widget_nav_menu"><h4 class="widget-title">Products</h4><div class="menu-footer-3-1-container"><ul id="menu-footer-3-1" class="menu"><li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-248" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-248 nav-item"><a title="Products" href="https://www.bakels.com.au/products/" class="nav-link">Products</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-249" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-249 nav-item"><a title="Recipes" href="https://www.bakels.com.au/recipes/" class="nav-link">Recipes</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-301" class="menu-item menu-item-type-post_type_archive menu-item-object-stockist menu-item-301 nav-item"><a title="Where to buy" href="https://www.bakels.com.au/stockist/" class="nav-link">Where to buy</a></li>
+</ul></div></div><div id="nav_menu-10" class="widget-area widget widget_nav_menu"><h4 class="widget-title">Services</h4><div class="menu-footer-3-2-container"><ul id="menu-footer-3-2" class="menu"><li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-251" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-251 nav-item"><a title="Centres of Competence" href="https://www.bakels.com.au/services/centres-of-competence/" class="nav-link">Centres of Competence</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-252" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-252 nav-item"><a title="Research &amp; Development" href="https://www.bakels.com.au/services/research-development/" class="nav-link">Research &#038; Development</a></li>
+</ul></div></div>            </div>
+            
+                        <div class="col-lg-2 col-md-4 col-12 footer-widget footer-widget-4">
+                <div id="nav_menu-11" class="widget-area widget widget_nav_menu"><h4 class="widget-title">Other</h4><div class="menu-footer-4-container"><ul id="menu-footer-4" class="menu"><li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-255" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-255 nav-item"><a title="Sitemap" href="https://www.bakels.com.au/sitemap/" class="nav-link">Sitemap</a></li>
+</ul></div></div>            </div>
+            
+                        <div class="col-lg-3 col-md-8 col-12 footer-widget footer-widget-5">
+                <div id="custom_html-4" class="widget_text widget-area widget widget_custom_html"><h4 class="widget-title">Head Office</h4><div class="textwidget custom-html-widget"><div class="row">
+	<div class="col-lg-12 col-md-6 col-12">
+		<p>
+			<span class="d-lg-block d-inline">33-47 Derby Street </span>
+			<span class="d-lg-block d-inline">Silverwater </span> 
+			 NSW 2128
+		</p>
+	</div>
+	<div class="col-lg-12 col-md-6 col-12">
+		<div class="widget-nav nav">
+			<ul class="navbar-nav">
+				<li class="nav-item phone-link">
+					<a tel="tel:61297399300">+61 2 9739 9300 </a>
+				</li>
+				<li class="nav-item email-link">
+					<a href="mailto:ausbak@bakels.com.au " class="nav-link">ausbak@bakels.com.au </a>
+				</li>
+			</ul>
+		</div>
+	</div>
+</div></div></div>
+                <div class="mt-4">
+                  <button type="button" class="btn btn-country d-lg-inline-block d-none" data-toggle="modal" data-target="#select-country">Select a market</button>
+                  <button class="btn btn-country select-country d-lg-none d-inline-block">Select a market</button>
+                </div>
+            </div>
+                    </div>
+
+      </div>
+    </div>
+
+    </div>
+  <div class="site-accreditation">
+    <div class="container">
+      <div class="row">
+        <div class="col-12 text-center">
+          <div class="slider-accreditation"><img width="101" height="120" src="https://www.bakels.com.au/wp-content/uploads/sites/21/2023/05/RSPO-AB-Logo-101x120.png" class="attachment-accreditation-logo size-accreditation-logo" alt="" decoding="async" srcset="https://www.bakels.com.au/wp-content/uploads/sites/21/2023/05/RSPO-AB-Logo-101x120.png 101w, https://www.bakels.com.au/wp-content/uploads/sites/21/2023/05/RSPO-AB-Logo-254x300.png 254w, https://www.bakels.com.au/wp-content/uploads/sites/21/2023/05/RSPO-AB-Logo-866x1024.png 866w, https://www.bakels.com.au/wp-content/uploads/sites/21/2023/05/RSPO-AB-Logo-768x909.png 768w, https://www.bakels.com.au/wp-content/uploads/sites/21/2023/05/RSPO-AB-Logo-1298x1536.png 1298w, https://www.bakels.com.au/wp-content/uploads/sites/21/2023/05/RSPO-AB-Logo-1731x2048.png 1731w, https://www.bakels.com.au/wp-content/uploads/sites/21/2023/05/RSPO-AB-Logo-300x355.png 300w, https://www.bakels.com.au/wp-content/uploads/sites/21/2023/05/RSPO-AB-Logo.png 2027w" sizes="(max-width: 101px) 100vw, 101px" /><img width="48" height="120" src="https://www.bakels.com.au/wp-content/uploads/sites/21/2023/05/HACCP-logo-e1683847695102-48x120.jpg" class="attachment-accreditation-logo size-accreditation-logo" alt="" decoding="async" srcset="https://www.bakels.com.au/wp-content/uploads/sites/21/2023/05/HACCP-logo-e1683847695102-48x120.jpg 48w, https://www.bakels.com.au/wp-content/uploads/sites/21/2023/05/HACCP-logo-e1683847695102-121x300.jpg 121w, https://www.bakels.com.au/wp-content/uploads/sites/21/2023/05/HACCP-logo-e1683847695102.jpg 240w" sizes="(max-width: 48px) 100vw, 48px" /><img width="160" height="120" src="https://www.bakels.com.au/wp-content/uploads/sites/21/2023/05/www.brcgs_-160x120.png" class="attachment-accreditation-logo size-accreditation-logo" alt="" decoding="async" srcset="https://www.bakels.com.au/wp-content/uploads/sites/21/2023/05/www.brcgs_-160x120.png 160w, https://www.bakels.com.au/wp-content/uploads/sites/21/2023/05/www.brcgs_-300x226.png 300w, https://www.bakels.com.au/wp-content/uploads/sites/21/2023/05/www.brcgs_.png 690w" sizes="(max-width: 160px) 100vw, 160px" /></div>        </div>
+      </div>
+    </div>
+  </div>
+  
+  <footer class="site-footer">
+    <div class="container">
+      <div class="row">
+        <div class="col-lg-4 col-md-4 col-12 text-md-left text-xs-center footer-left">
+          <div class="widget-area">
+            <div class="widget-text">
+              <p>&copy; 2024 Australian Bakels</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-4 col-12 text-xs-center footer-center">
+          <div class="widget-area">
+            <div class="widget-text">
+              <a href="https://www.bakels.com.au" title="Australian Bakels">
+                <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/logo-footer.svg" alt="Australian Bakels">
+              </a>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-4 col-12 footer-right text-md-right text-xs-center">
+          <div class="widget-area">
+            <div class="widget-text">
+              <p class="dnp">
+                                Website by <a href="https://www.impactmedia.co.uk/" target="_blank" rel="nofollow">Impact Media</a>&reg; <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/logo-im.svg" alt="Impact Media" class="ml-2 dnp">
+              </p>
+
+              <p>
+               <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/logo-blue.svg" alt="Australian Bakels" class="print-logo-footer">
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+</div>
+<!-- END CONTAINER -->
+
+<div class="sidr-bg"></div>
+
+<div id="mobile-nav" class="sidr left">
+  <ul class="sidr-class-menu sidr-class-menu-top"><li class="sidr-class-item sidr-depth-1 sidr-level-header"><span class="sidr-label">Navigation</span><a class="menu-btn"><img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu"></a></li><li id="menu-item-270" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-270 sidr-class-item sidr-class-menuparent sidr-depth-1 product-category"><a title="Products" href="https://www.bakels.com.au/products/" class="sidr-class-link sidr-class-menuparent">Products</a>
+<ul  class="sidr-class-submenu"><li class="sidr-class-item sidr-level-header sidr-depth-2"><a class="sidr-level-back">Back</a><a class="menu-btn"><img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu"></a></li><li class="sidr-class-item sidr-depth-2"><a href="https://www.bakels.com.au/products/" class="sidr-class-link">Products</a></li>
+	<li id="menu-item-33" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-33 sidr-class-item nav-item-col-1 menu-item-has-children menu-item-parent-1757 sidr-depth-2"><a title="Bread, Roll &amp; Morning Goods" href="https://www.bakels.com.au/product-category/bread-roll-morning-goods/" class="sidr-class-link sidr-class-menuparent">Bread, Roll &amp; Morning Goods</a><ul class="sidr-class-submenu"><li class="sidr-class-item sidr-level-header sidr-depth-3"><a class="sidr-level-back">Back</a><a class="menu-btn"><img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu"></a></li><li class="sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/bread-roll-morning-goods/" class="sidr-class-link">Bread, Roll &amp; Morning Goods</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3641 sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/bread-mixes-concentrates/" class="sidr-class-link">Bread Mixes and Concentrates</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3634 sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/bread-improvers/" class="sidr-class-link">Bread Improvers</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3631 sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/bread-toppings/" class="sidr-class-link">Bread Toppings</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-5541 sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/donut-mixes-and-concentrates/" class="sidr-class-link">Donut Mixes and Concentrates</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-5542 sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/yeast/" class="sidr-class-link">Yeast</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-5543 sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/sourdough-products/" class="sidr-class-link">Sourdough Products</a></li></ul></li>
+	<li id="menu-item-34" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-34 sidr-class-item nav-item-col-1 menu-item-has-children menu-item-parent-4398 sidr-depth-2"><a title="Fats &amp; Oils" href="https://www.bakels.com.au/product-category/fats-oils/" class="sidr-class-link sidr-class-menuparent">Fats &amp; Oils</a><ul class="sidr-class-submenu"><li class="sidr-class-item sidr-level-header sidr-depth-3"><a class="sidr-level-back">Back</a><a class="menu-btn"><img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu"></a></li><li class="sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/fats-oils/" class="sidr-class-link">Fats &amp; Oils</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3642 sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/pastry-margarines/" class="sidr-class-link">Pastry Margarines</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3638 sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/release-solutions/" class="sidr-class-link">Release Solutions</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3625 sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/specialised-bread-bun-fats/" class="sidr-class-link">Specialised Fats</a></li></ul></li>
+	<li id="menu-item-35" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-35 sidr-class-item nav-item-col-1 sidr-depth-2"><a title="Frozen Pastry" href="https://www.bakels.com.au/product-category/frozen-pastry/" class="sidr-class-link">Frozen Pastry</a></li>
+	<li id="menu-item-36" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-36 sidr-class-item nav-item-col-1 sidr-depth-2"><a title="Gluten Free Products" href="https://www.bakels.com.au/product-category/gluten-free-products/" class="sidr-class-link">Gluten Free Products</a></li>
+	<li id="menu-item-37" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-37 sidr-class-item nav-item-col-1 sidr-depth-2"><a title="Preservatives" href="https://www.bakels.com.au/product-category/preservatives/" class="sidr-class-link">Preservatives</a></li>
+	<li id="menu-item-38" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-38 sidr-class-item nav-item-col-1 sidr-depth-2"><a title="Specialised Pie &amp; Potato Products" href="https://www.bakels.com.au/product-category/specialised-pie-potato-products/" class="sidr-class-link">Specialised Pie &amp; Potato Products</a></li>
+	<li id="menu-item-39" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-39 sidr-class-item nav-item-col-1 sidr-depth-2"><a title="Various Pastry Cooking Products" href="https://www.bakels.com.au/product-category/various-pastry-cooking-products/" class="sidr-class-link">Various Pastry Cooking Products</a></li>
+	<li id="menu-item-40" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-40 sidr-class-item nav-item-col-1 menu-item-has-children menu-item-parent-5544 sidr-depth-2"><a title="Cake and Sponge" href="https://www.bakels.com.au/product-category/cake-and-sponge/" class="sidr-class-link sidr-class-menuparent">Cake and Sponge</a><ul class="sidr-class-submenu"><li class="sidr-class-item sidr-level-header sidr-depth-3"><a class="sidr-level-back">Back</a><a class="menu-btn"><img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu"></a></li><li class="sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/cake-and-sponge/" class="sidr-class-link">Cake and Sponge</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3664 sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/raising-agents/" class="sidr-class-link">Raising Agents</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-4914 sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/muffin-mixes/" class="sidr-class-link">Muffin Mixes</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3645 sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/sponge-cake-emulsifiers-cake-margarines/" class="sidr-class-link">Sponge &amp; Cake Emulsifiers- Cake- Margarines</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-4889 sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/sponge-cake-premixes/" class="sidr-class-link">Sponge &amp; Cake Premixes</a></li></ul></li>
+	<li id="menu-item-41" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-41 sidr-class-item nav-item-col-1 menu-item-has-children menu-item-parent-5545 sidr-depth-2"><a title="Cookie and Biscuit" href="https://www.bakels.com.au/product-category/cookie-and-biscuit/" class="sidr-class-link sidr-class-menuparent">Cookie and Biscuit</a><ul class="sidr-class-submenu"><li class="sidr-class-item sidr-level-header sidr-depth-3"><a class="sidr-level-back">Back</a><a class="menu-btn"><img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu"></a></li><li class="sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/cookie-and-biscuit/" class="sidr-class-link">Cookie and Biscuit</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-4913 sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/cookie-biscuit-mixes/" class="sidr-class-link">Cookie &amp; Biscuit Mixes</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3669 sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/frozen-cookies/" class="sidr-class-link">Frozen Cookies</a></li></ul></li>
+	<li id="menu-item-42" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-42 sidr-class-item nav-item-col-1 menu-item-has-children menu-item-parent-5546 sidr-depth-2"><a title="Confectionary" href="https://www.bakels.com.au/product-category/confectionary/" class="sidr-class-link sidr-class-menuparent">Confectionary</a><ul class="sidr-class-submenu"><li class="sidr-class-item sidr-level-header sidr-depth-3"><a class="sidr-level-back">Back</a><a class="menu-btn"><img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu"></a></li><li class="sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/confectionary/" class="sidr-class-link">Confectionary</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3656 sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/cheesecake-mixes/" class="sidr-class-link">Cheesecake Mixes</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3648 sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/caramel-and-creme-fillings/" class="sidr-class-link">Caramel and Creme Fillings</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-4968 sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/custard-and-creme-mixes/" class="sidr-class-link">Custard and Creme Mixes</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3661 sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/flavouring-pastes-essences-colours/" class="sidr-class-link">Flavouring Pastes, Essences &amp; Colours</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3657 sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/fondants-chocolate-ganache-truffles/" class="sidr-class-link">Fondants, Chocolate, Ganache &amp; Truffles</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3651 sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/fruit-flavoured-fillings/" class="sidr-class-link">Fruit &amp; Fruit Flavoured Fillings</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3658 sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/glazes-piping-gels-dips/" class="sidr-class-link">Glazes, Piping Gels &amp; Dips</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3659 sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/icings-icing-sugars/" class="sidr-class-link">Icings &amp; Icing Sugars</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3666 sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/meringue-and-mallow-mixes/" class="sidr-class-link">Meringue and Mallow Mixes</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-4971 sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/mousse-mixes/" class="sidr-class-link">Mousse Mixes</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3650 sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/product-category/slice-mixes-bases/" class="sidr-class-link">Slice Mixes &amp; Bases</a></li></ul></li>
+</ul>
+</li>
+<li id="menu-item-271" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-271 sidr-class-item sidr-class-menuparent sidr-depth-1 recipe-category"><a title="Recipes" href="https://www.bakels.com.au/recipes/" class="sidr-class-link sidr-class-menuparent">Recipes</a>
+<ul  class="sidr-class-submenu"><li class="sidr-class-item sidr-level-header sidr-depth-2"><a class="sidr-level-back">Back</a><a class="menu-btn"><img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu"></a></li><li class="sidr-class-item sidr-depth-2"><a href="https://www.bakels.com.au/recipes/" class="sidr-class-link">Recipes</a></li>
+	<li id="menu-item-43" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-43 sidr-class-item nav-item-col-1 sidr-depth-2"><a title="Bakery" href="https://www.bakels.com.au/recipe-category/bakery/" class="sidr-class-link">Bakery</a></li>
+	<li id="menu-item-44" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-44 sidr-class-item nav-item-col-1 sidr-depth-2"><a title="Patisserie" href="https://www.bakels.com.au/recipe-category/patisserie/" class="sidr-class-link">Patisserie</a></li>
+</ul>
+</li>
+<li id="menu-item-269" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-269 sidr-class-item sidr-class-menuparent sidr-depth-1"><a title="About" href="https://www.bakels.com.au/about/" class="sidr-class-link sidr-class-menuparent">About</a>
+<ul  class="sidr-class-submenu"><li class="sidr-class-item sidr-level-header sidr-depth-2"><a class="sidr-level-back">Back</a><a class="menu-btn"><img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu"></a></li><li class="sidr-class-item sidr-depth-2"><a href="https://www.bakels.com.au/about/" class="sidr-class-link">About</a></li>
+	<li id="menu-item-275" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-275 sidr-class-item sidr-depth-2"><a title="Core Values" href="https://www.bakels.com.au/about/core-values/" class="sidr-class-link">Core Values</a></li>
+	<li id="menu-item-276" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-276 sidr-class-item sidr-depth-2"><a title="Facts &amp; Figures" href="https://www.bakels.com.au/about/facts-figures/" class="sidr-class-link">Facts &amp; Figures</a></li>
+	<li id="menu-item-277" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-277 sidr-class-item sidr-depth-2"><a title="History" href="https://www.bakels.com.au/about/history/" class="sidr-class-link">History</a></li>
+	<li id="menu-item-278" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-278 sidr-class-item sidr-depth-2"><a title="Jobs" href="https://www.bakels.com.au/about/jobs/" class="sidr-class-link">Jobs</a></li>
+	<li id="menu-item-279" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-279 sidr-class-item sidr-depth-2"><a title="Mission Statement" href="https://www.bakels.com.au/about/mission-statement/" class="sidr-class-link">Mission Statement</a></li>
+	<li id="menu-item-280" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-280 sidr-class-item sidr-depth-2"><a title="Our Customers" href="https://www.bakels.com.au/about/our-customers/" class="sidr-class-link">Our Customers</a></li>
+	<li id="menu-item-3597" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3597 sidr-class-item sidr-depth-2"><a title="Australian Bakels" href="https://www.bakels.com.au/local/" class="sidr-class-link">Australian Bakels</a></li>
+</ul>
+</li>
+<li id="menu-item-272" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-272 sidr-class-item sidr-class-menuparent sidr-depth-1"><a title="Services" href="https://www.bakels.com.au/services/" class="sidr-class-link sidr-class-menuparent">Services</a>
+<ul  class="sidr-class-submenu"><li class="sidr-class-item sidr-level-header sidr-depth-2"><a class="sidr-level-back">Back</a><a class="menu-btn"><img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu"></a></li><li class="sidr-class-item sidr-depth-2"><a href="https://www.bakels.com.au/services/" class="sidr-class-link">Services</a></li>
+	<li id="menu-item-281" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-281 sidr-class-item sidr-depth-2"><a title="Centres of Competence" href="https://www.bakels.com.au/services/centres-of-competence/" class="sidr-class-link">Centres of Competence</a></li>
+	<li id="menu-item-15429" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-15429 sidr-class-item sidr-class-menuparent sidr-depth-2"><a title="Baking Centres" href="https://www.bakels.com.au/baking-centres/" class="sidr-class-link sidr-class-menuparent">Baking Centres</a>
+	<ul  class="sidr-class-submenu"><li class="sidr-class-item sidr-level-header sidr-depth-3"><a class="sidr-level-back">Back</a><a class="menu-btn"><img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu"></a></li><li class="sidr-class-item sidr-depth-3"><a href="https://www.bakels.com.au/baking-centres/" class="sidr-class-link">Baking Centres</a></li>
+		<li id="menu-item-17924" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-17924 sidr-class-item sidr-depth-3"><a title="Switzerland" href="https://www.bakels.com.au/services/baking-centres/switzerland/" class="sidr-class-link">Switzerland</a></li>
+		<li id="menu-item-17923" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-17923 sidr-class-item sidr-depth-3"><a title="British Bakels" href="https://www.bakels.com.au/services/baking-centres/british-bakels/" class="sidr-class-link">British Bakels</a></li>
+		<li id="menu-item-17922" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-17922 sidr-class-item sidr-depth-3"><a title="Australia" href="https://www.bakels.com.au/services/baking-centres/australia/" class="sidr-class-link">Australia</a></li>
+		<li id="menu-item-17921" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-17921 sidr-class-item sidr-depth-3"><a title="Thailand" href="https://www.bakels.com.au/services/baking-centres/thailand/" class="sidr-class-link">Thailand</a></li>
+		<li id="menu-item-17920" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-17920 sidr-class-item sidr-depth-3"><a title="Belgium" href="https://www.bakels.com.au/services/baking-centres/belgium/" class="sidr-class-link">Belgium</a></li>
+		<li id="menu-item-17919" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-17919 sidr-class-item sidr-depth-3"><a title="Ecuador" href="https://www.bakels.com.au/services/baking-centres/ecuador/" class="sidr-class-link">Ecuador</a></li>
+		<li id="menu-item-18381" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-18381 sidr-class-item sidr-depth-3"><a title="Mainland China" href="https://www.bakels.com.au/services/baking-centres/mainland-china/" class="sidr-class-link">Mainland China</a></li>
+		<li id="menu-item-18377" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-18377 sidr-class-item sidr-depth-3"><a title="Sweden" href="https://www.bakels.com.au/services/baking-centres/sweden/" class="sidr-class-link">Sweden</a></li>
+		<li id="menu-item-18380" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-18380 sidr-class-item sidr-depth-3"><a title="Malaysia" href="https://www.bakels.com.au/services/baking-centres/malaysia/" class="sidr-class-link">Malaysia</a></li>
+		<li id="menu-item-18378" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-18378 sidr-class-item sidr-depth-3"><a title="Hong Kong" href="https://www.bakels.com.au/services/baking-centres/hong-kong/" class="sidr-class-link">Hong Kong</a></li>
+		<li id="menu-item-18379" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-18379 sidr-class-item sidr-depth-3"><a title="India" href="https://www.bakels.com.au/services/baking-centres/india/" class="sidr-class-link">India</a></li>
+		<li id="menu-item-18401" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-18401 sidr-class-item sidr-depth-3"><a title="The Netherlands" href="https://www.bakels.com.au/services/baking-centres/bakels-senior/" class="sidr-class-link">The Netherlands</a></li>
+		<li id="menu-item-18604" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-18604 sidr-class-item sidr-depth-3"><a title="Germany" href="https://www.bakels.com.au/services/baking-centres/germany/" class="sidr-class-link">Germany</a></li>
+		<li id="menu-item-29032" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-29032 sidr-class-item sidr-depth-3"><a title="Chile" href="https://www.bakels.com.au/services/baking-centres/chile/" class="sidr-class-link">Chile</a></li>
+	</ul>
+</li>
+	<li id="menu-item-282" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-282 sidr-class-item sidr-depth-2"><a title="Research &amp; Development" href="https://www.bakels.com.au/services/research-development/" class="sidr-class-link">Research &amp; Development</a></li>
+</ul>
+</li>
+<li id="menu-item-3781" class="menu-item menu-item-type-post_type menu-item-object-page current_page_parent menu-item-3781 sidr-class-item sidr-depth-1"><a title="News" href="https://www.bakels.com.au/news/" class="sidr-class-link">News</a></li>
+<li id="menu-item-300" class="menu-item menu-item-type-post_type_archive menu-item-object-stockist menu-item-300 sidr-class-item sidr-depth-1"><a title="Where to buy" href="https://www.bakels.com.au/stockist/" class="sidr-class-link">Where to buy</a></li>
+<li id="menu-item-273" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-273 sidr-class-item sidr-depth-1"><a title="Contact" href="https://www.bakels.com.au/contact/" class="sidr-class-link">Contact</a></li>
+<li id="menu-item-3432" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3432 sidr-class-item sidr-depth-1"><a title="My Bakels" href="https://www.bakels.com.au/my-bakels/" class="sidr-class-link">My Bakels</a></li>
+</ul><ul class="sidr-class-menu sidr-class-menu-top"><li id="menu-item-3473" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3473 sidr-class-item sidr-depth-1"><a title="Login" href="https://www.bakels.com.au/my-bakels/login/" class="sidr-class-link">Login</a></li>
+<li id="menu-item-3474" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3474 sidr-class-item sidr-depth-1"><a title="Register" href="https://www.bakels.com.au/my-bakels/register/" class="sidr-class-link">Register</a></li>
+</ul></div><div id="country-nav" class="sidr left">
+  <ul class="sidr-class-menu sidr-class-menu-top">
+    <li class="sidr-class-item sidr-depth-1 sidr-level-header">
+      <span class="sidr-label">Select a Market</span>
+      <a class="menu-btn">
+        <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+      </a>
+    </li>
+
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent" id="sidr-list-africa">
+      <a class="sidr-class-link sidr-class-menuparent">Africa</a>
+              <ul class="sidr-class-submenu">
+          <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+            <a class="sidr-level-back">Back</a>
+            <a class="menu-btn">
+              <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+            </a>
+          </li>
+
+          <li class="sidr-class-item sidr-depth-2"><a href="http://www.sbakels.co.za" class="sidr-class-link">South Africa</a></li>        </ul>
+          </li>
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent" id="sidr-list-antarctica">
+      <a class="sidr-class-link sidr-class-menuparent">Antarctica</a>
+              <ul class="sidr-class-submenu">
+          <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+            <a class="sidr-level-back">Back</a>
+            <a class="menu-btn">
+              <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+            </a>
+          </li>
+
+                  </ul>
+          </li>
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent" id="sidr-list-asia">
+      <a class="sidr-class-link sidr-class-menuparent">Asia</a>
+              <ul class="sidr-class-submenu">
+          <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+            <a class="sidr-level-back">Back</a>
+            <a class="menu-btn">
+              <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+            </a>
+          </li>
+
+          <li class="sidr-class-item sidr-depth-2"><a href="http://www.hkbakels.com.hk" class="sidr-class-link">Hong Kong</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakels.in" class="sidr-class-link">India</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://http://www.bakels.com.cn/" class="sidr-class-link">Mainland China</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.maybakels.com" class="sidr-class-link">Malaysia</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakelsph.com" class="sidr-class-link">Philippines</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakelsingapore.com.sg" class="sidr-class-link">Singapore</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakels.co.th" class="sidr-class-link">Thailand</a></li>        </ul>
+          </li>
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent" id="sidr-list-europe">
+      <a class="sidr-class-link sidr-class-menuparent">Europe</a>
+              <ul class="sidr-class-submenu">
+          <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+            <a class="sidr-level-back">Back</a>
+            <a class="menu-btn">
+              <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+            </a>
+          </li>
+
+          <li class="sidr-class-item sidr-depth-2"><a href="http://www.bakbel.com" class="sidr-class-link">Belgium</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.finnbakels.fi" class="sidr-class-link">Finland</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakelsdeutschland.de" class="sidr-class-link">Germany</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakels.hu" class="sidr-class-link">Hungary</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.irishbakels.ie" class="sidr-class-link">Ireland</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakels-senior.nl" class="sidr-class-link">Netherlands</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakels.pl" class="sidr-class-link">Poland</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.nordbakels.se" class="sidr-class-link">Sweden</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakels.ch" class="sidr-class-link">Switzerland</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.britishbakels.co.uk" class="sidr-class-link">United Kingdom</a></li>        </ul>
+          </li>
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent" id="sidr-list-oceania">
+      <a class="sidr-class-link sidr-class-menuparent">Oceania</a>
+              <ul class="sidr-class-submenu">
+          <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+            <a class="sidr-level-back">Back</a>
+            <a class="menu-btn">
+              <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+            </a>
+          </li>
+
+          <li class="sidr-class-item sidr-depth-2"><a href="http://www.bakels.com.au" class="sidr-class-link">Australia</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakelsfiji.com.fj" class="sidr-class-link">Fiji</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.nzbakels.co.nz" class="sidr-class-link">New Zealand</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.beobakels.co.nz" class="sidr-class-link">New Zealand - Edible Oils</a></li>        </ul>
+          </li>
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent" id="sidr-list-north-america">
+      <a class="sidr-class-link sidr-class-menuparent">North America</a>
+              <ul class="sidr-class-submenu">
+          <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+            <a class="sidr-level-back">Back</a>
+            <a class="menu-btn">
+              <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+            </a>
+          </li>
+
+          <li class="sidr-class-item sidr-depth-2"><a href="http://www.bakelsusa.com" class="sidr-class-link">United States</a></li>        </ul>
+          </li>
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent" id="sidr-list-south-america">
+      <a class="sidr-class-link sidr-class-menuparent">South America</a>
+              <ul class="sidr-class-submenu">
+          <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+            <a class="sidr-level-back">Back</a>
+            <a class="menu-btn">
+              <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+            </a>
+          </li>
+
+          <li class="sidr-class-item sidr-depth-2"><a href="http://www.bakels.com.br" class="sidr-class-link">Brazil</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakelschile.cl" class="sidr-class-link">Chile</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakels.com.ec" class="sidr-class-link">Ecuador</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakels.pe" class="sidr-class-link">Peru</a></li>        </ul>
+          </li>
+    
+    <li class="sidr-class-item sidr-depth-1" id="sidr-list-group">
+      <a href="https://www.bakels.com/" target="_blank" class="sidr-class-link">Visit Bakels Group</a>
+    </li>
+
+  </ul>
+</div>
+<div id="product-nav" class="sidr right">
+  <ul class="sidr-class-menu sidr-class-menu-top">
+    <li class="sidr-class-item sidr-depth-1 sidr-level-header">
+      <span class="sidr-label">Filter Products</span>
+      <a class="menu-btn">
+        <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+      </a>
+    </li>
+
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Categories</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link sidr-class-menuparent" >Bread, Roll &amp; Morning Goods</a>
+
+                    <ul class="sidr-class-submenu">
+            <li class="sidr-class-item sidr-depth-3 sidr-level-header">
+              <a class="sidr-level-back">Back</a>
+              <a class="menu-btn">
+                <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+              </a>
+            </li>
+            <li class="sidr-class-item sidr-depth-3">
+              <a class="sidr-class-link" href="https://www.bakels.com.au/products/?product-category%5B%5D=1757">Bread, Roll &amp; Morning Goods</a>
+            </li>
+
+                            <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=3631" class="sidr-class-link">Bread Toppings</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=3634" class="sidr-class-link">Bread Improvers</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=3641" class="sidr-class-link">Bread Mixes and Concentrates</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=5541" class="sidr-class-link">Donut Mixes and Concentrates</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=5542" class="sidr-class-link">Yeast</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=5543" class="sidr-class-link">Sourdough Products</a>
+                </li>
+                          </ul>
+                </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link sidr-class-menuparent" >Fats &amp; Oils</a>
+
+                    <ul class="sidr-class-submenu">
+            <li class="sidr-class-item sidr-depth-3 sidr-level-header">
+              <a class="sidr-level-back">Back</a>
+              <a class="menu-btn">
+                <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+              </a>
+            </li>
+            <li class="sidr-class-item sidr-depth-3">
+              <a class="sidr-class-link" href="https://www.bakels.com.au/products/?product-category%5B%5D=4398">Fats &amp; Oils</a>
+            </li>
+
+                            <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=3625" class="sidr-class-link">Specialised Fats</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=3638" class="sidr-class-link">Release Solutions</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=3642" class="sidr-class-link">Pastry Margarines</a>
+                </li>
+                          </ul>
+                </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?product-category%5B%5D=3667" >Frozen Pastry</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?product-category%5B%5D=3646" >Gluten Free Products</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?product-category%5B%5D=3663" >Preservatives</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?product-category%5B%5D=3644" >Specialised Pie &amp; Potato Products</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?product-category%5B%5D=3665" >Various Pastry Cooking Products</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link sidr-class-menuparent" >Cake and Sponge</a>
+
+                    <ul class="sidr-class-submenu">
+            <li class="sidr-class-item sidr-depth-3 sidr-level-header">
+              <a class="sidr-level-back">Back</a>
+              <a class="menu-btn">
+                <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+              </a>
+            </li>
+            <li class="sidr-class-item sidr-depth-3">
+              <a class="sidr-class-link" href="https://www.bakels.com.au/products/?product-category%5B%5D=5544">Cake and Sponge</a>
+            </li>
+
+                            <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=3645" class="sidr-class-link">Sponge &amp; Cake Emulsifiers- Cake- Margarines</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=3664" class="sidr-class-link">Raising Agents</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=4889" class="sidr-class-link">Sponge &amp; Cake Premixes</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=4914" class="sidr-class-link">Muffin Mixes</a>
+                </li>
+                          </ul>
+                </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link sidr-class-menuparent" >Cookie and Biscuit</a>
+
+                    <ul class="sidr-class-submenu">
+            <li class="sidr-class-item sidr-depth-3 sidr-level-header">
+              <a class="sidr-level-back">Back</a>
+              <a class="menu-btn">
+                <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+              </a>
+            </li>
+            <li class="sidr-class-item sidr-depth-3">
+              <a class="sidr-class-link" href="https://www.bakels.com.au/products/?product-category%5B%5D=5545">Cookie and Biscuit</a>
+            </li>
+
+                            <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=3669" class="sidr-class-link">Frozen Cookies</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=4913" class="sidr-class-link">Cookie &amp; Biscuit Mixes</a>
+                </li>
+                          </ul>
+                </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link sidr-class-menuparent" >Confectionary</a>
+
+                    <ul class="sidr-class-submenu">
+            <li class="sidr-class-item sidr-depth-3 sidr-level-header">
+              <a class="sidr-level-back">Back</a>
+              <a class="menu-btn">
+                <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+              </a>
+            </li>
+            <li class="sidr-class-item sidr-depth-3">
+              <a class="sidr-class-link" href="https://www.bakels.com.au/products/?product-category%5B%5D=5546">Confectionary</a>
+            </li>
+
+                            <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=3648" class="sidr-class-link">Caramel and Creme Fillings</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=3650" class="sidr-class-link">Slice Mixes &amp; Bases</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=3651" class="sidr-class-link">Fruit &amp; Fruit Flavoured Fillings</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=3656" class="sidr-class-link">Cheesecake Mixes</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=3657" class="sidr-class-link">Fondants, Chocolate, Ganache &amp; Truffles</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=3658" class="sidr-class-link">Glazes, Piping Gels &amp; Dips</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=3659" class="sidr-class-link">Icings &amp; Icing Sugars</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=3661" class="sidr-class-link">Flavouring Pastes, Essences &amp; Colours</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=3666" class="sidr-class-link">Meringue and Mallow Mixes</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=4968" class="sidr-class-link">Custard and Creme Mixes</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=4971" class="sidr-class-link">Mousse Mixes</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.bakels.com.au/products/?product-category%5B%5D=5218" class="sidr-class-link">Toppings</a>
+                </li>
+                          </ul>
+                </li>
+            </ul>
+    </li>
+    
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Finished product</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1860" >Baguette</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4454" >Balec</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4116" >Banana Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1899" >Batter Coating</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1884" >Biscuit</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4117" >Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4025" >Bread Roll</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1876" >Brioche</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1905" >Brownie</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4237" >Buttacake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4250" >Butter Cherry Bars</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4331" >Buttercream</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1882" >Cake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link sidr-class-menuparent" >Cake Margarine</a>
+
+                    <ul class="sidr-class-submenu">
+            <li class="sidr-class-item sidr-depth-3 sidr-level-header">
+              <a class="sidr-level-back">Back</a>
+              <a class="menu-btn">
+                <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+              </a>
+            </li>
+            <li class="sidr-class-item sidr-depth-3">
+              <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4196">Cake Margarine</a>
+            </li>
+
+                          <li class="sidr-class-item sidr-depth-3">
+                <a href="https://www.bakels.com.au/products/?finished-products%5B%5D=4405" class="sidr-class-link">Emulsifier</a>
+              </li>
+                      </ul>
+                </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1890" >Cheesecake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1896" >Chilled Dough</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4366" >Chocolate Hedgehog Slice Mix</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1906" >Choux</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1854" >Ciabatta</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1885" >Confectionery</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1861" >Cookies</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1859" >Cracker</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4321" >Cream</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4456" >Cream Puffs and Eclairs</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=2937" >Creme Cake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1875" >Croissant</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1893" >Crumpet</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1868" >Crusty Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1857" >Crusty Roll</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1912" >Cupcake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1910" >Custard</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1874" >Danish</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1907" >Dessert</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1878" >Doughnut</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link sidr-class-menuparent" >Fats and Oils</a>
+
+                    <ul class="sidr-class-submenu">
+            <li class="sidr-class-item sidr-depth-3 sidr-level-header">
+              <a class="sidr-level-back">Back</a>
+              <a class="menu-btn">
+                <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+              </a>
+            </li>
+            <li class="sidr-class-item sidr-depth-3">
+              <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4034">Fats and Oils</a>
+            </li>
+
+                          <li class="sidr-class-item sidr-depth-3">
+                <a href="https://www.bakels.com.au/products/?finished-products%5B%5D=4397" class="sidr-class-link">Vegetable Shortening</a>
+              </li>
+                      </ul>
+                </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4945" >Fillings</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1873" >Flat Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=5223" >Flavouring Paste</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4209" >Flour</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4979" >Fondant</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1897" >Frozen Dough</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1889" >Fruit Tart</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1891" >Gateaux</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1894" >Genoese</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=5014" >Glazes</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1866" >Gluten Free</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1870" >Hamburger Bun</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1871" >Hot Cross Bun</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1911" >Ice Cream</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4090" >Icings</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=5548" >Macaron</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1895" >Madeira</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=5547" >Marshmallow</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4171" >Meat Pie</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1902" >Meringue</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4148" >Mock Cream</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4972" >Mousses</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4271" >Mud Cake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1903" >Muffin</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1864" >Multiseed</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1898" >Naan</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4377" >Neutral Hedgehog Slice</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1855" >Occasion Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1880" >Organic</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1892" >Pancake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1865" >Panettone</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4118" >Pastry Gems</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=5549" >Pavlova</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link sidr-class-menuparent" >Pie</a>
+
+                    <ul class="sidr-class-submenu">
+            <li class="sidr-class-item sidr-depth-3 sidr-level-header">
+              <a class="sidr-level-back">Back</a>
+              <a class="menu-btn">
+                <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+              </a>
+            </li>
+            <li class="sidr-class-item sidr-depth-3">
+              <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4153">Pie</a>
+            </li>
+
+                          <li class="sidr-class-item sidr-depth-3">
+                <a href="https://www.bakels.com.au/products/?finished-products%5B%5D=4399" class="sidr-class-link">Pastry Relaxer</a>
+              </li>
+                          <li class="sidr-class-item sidr-depth-3">
+                <a href="https://www.bakels.com.au/products/?finished-products%5B%5D=4400" class="sidr-class-link">Instant Starch</a>
+              </li>
+                          <li class="sidr-class-item sidr-depth-3">
+                <a href="https://www.bakels.com.au/products/?finished-products%5B%5D=4403" class="sidr-class-link">Cook Up Starch</a>
+              </li>
+                      </ul>
+                </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4154" >Pie Base</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4159" >Pie Bottoms</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1881" >Pizza</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4187" >Potato Pie Mash</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4182" >Quiche</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4461" >Rocky Road Hedgehog Slice</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1858" >Rye Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1888" >Sausage Roll</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1887" >Savoury Good</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1862" >Scone</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1877" >Scotch Roll</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1900" >Self Raising Flour</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4127" >Shortpaste Margarine</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1908" >Sliced Line</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4346" >Slices</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4355" >Snack Slice</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1863" >Soft Roll</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1856" >Sourdough</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1869" >Speciality Bun</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1883" >Sponge</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1879" >Stollen</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1872" >Sweet Good</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1886" >Swiss Roll</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4676" >Tiger Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1853" >Tin Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1909" >Traybake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4081" >Various Bread Products</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=5201" >Various Pastry Products</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4197" >Vegetable Cake Margarine</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4123" >Vegetable Pastry Nuggets</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1901" >Wafer</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=5587" >Waffles</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=1867" >Wholemeal</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?finished-products%5B%5D=4113" >Yeast</a>
+
+                  </li>
+            </ul>
+    </li>
+    
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Brand</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?brands%5B%5D=1691" >Country Oven</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?brands%5B%5D=5530" >Fermdor</a>
+
+                  </li>
+            </ul>
+    </li>
+    
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Ingredient Features</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?dietary%5B%5D=1800" >Gluten Free</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?dietary%5B%5D=1798" >Vegan</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/products/?dietary%5B%5D=1799" >Vegetarian</a>
+
+                  </li>
+            </ul>
+    </li>
+      </ul>
+</div>
+
+<div id="recipe-nav" class="sidr right">
+  <ul class="sidr-class-menu sidr-class-menu-top">
+    <li class="sidr-class-item sidr-depth-1 sidr-level-header">
+      <span class="sidr-label">Filter Recipes</span>
+      <a class="menu-btn">
+        <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+      </a>
+    </li>
+
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Categories</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?recipe-category%5B%5D=1796" >Bakery</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?recipe-category%5B%5D=1797" >Patisserie</a>
+
+                  </li>
+            </ul>
+    </li>
+    
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Bakels products</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15681">Actiwhite</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15527">Advance 1000 Improver</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15530">Advance 500 Improver</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17896">American Rye Bread Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15663">Apito Chocolate Flavour Paste</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17337">Apito Essences - Bun Spice</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15667">Apito Essences - Butta Vanilla</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17285">Apito Flavouring Paste - Coffee</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17861">Apito Flavouring Paste - Orange</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15773">Apito Flavouring Paste - Raspberry</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17262">Apito Flavouring Paste - Rum</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15774">Apito Flavouring Paste - Strawberry</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17217">Apito Superglaze</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17209">Apito Superglaze - Apricot</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15586">Apito Utility Cake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17013">Bakels All In Choc Mud Cake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17027">Bakels All-In Buttacake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15600">Bakels All-In Choc Chunk Brownie Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17024">Bakels All-In Muffin Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=16695">Bakels All-In Sponge Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15585">Bakels Buttacake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17770">Bakels Cake Donut Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17767">Bakels Caramel Flavoured Delite Cake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15630">Bakels Chocolate Ganache - MB</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15603">Bakels Chocolate Hedgehog Slice Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17507">Bakels Chocolate Muffin Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17818">Bakels Ciabatta Bread Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15567">Bakels Cook Up Starch</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17779">Bakels Cream Cheese Icing Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15587">Bakels Creme Cake Muffin Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15619">Bakels Custard Tart Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15526">Bakels Dobrim 500 Improver</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15523">Bakels Extra 1% Improver</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15540">Bakels Fermdor W Classic</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17005">Bakels Fruit Cake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15583">Bakels Gluten Free Artisan Bread Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15579">Bakels Gluten Free Health Baking Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15580">Bakels Gluten Free Health Flour</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17083">Bakels Gourmet Carrot Cake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17164">Bakels Gourmet Cheesecake Mix MB</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17765">Bakels Homestyle Cake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15533">Bakels Instant Active Dry Yeast (Angel)</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15621">Bakels Instant Continental Custard Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15594">Bakels Instant Crème Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15620">Bakels Instant Custard Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17773">Bakels Instant Snowflake Custard Mix NAFNAC</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15566">Bakels Instant Starch</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15610">Bakels Les Fruits 50% Raspberry Filling</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17749">Bakels Light Fruit Cake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17754">Bakels Lite Cake Muffin Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15684">Bakels Macaron Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15589">Bakels Millionaires Mud Cake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15588">Bakels Mud Cake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15584">Bakels Multi-Purpose Sponge Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15765">Bakels Neutral Hedgehog Slice Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15614">Bakels Pie Fillings - Dark Cherry 50%</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=16414">Bakels Pie Fillings - Strawberry 50%</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=18046">Bakels Plant-Based Yeast Raised Donut Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15521">Bakels Quantum CL 1000 Improver</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15522">Bakels Quantum Plus Improver</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15590">Bakels Red Velvet Cake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17837">Bakels Rich Dark Mud Cake Concentrate</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15679">Bakels Scone Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17937">Bakels Shortbread Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17095">Bakels Slice Base Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17751">Bakels Sticky Date Cake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15635">Bakels Super Glossy</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=16692">Bakels Tiger Paste Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=18037">Bakels Vanilla Patisserie Filling Mix NAFNAC</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15592">Bakels White Mud Cake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15632">Bakels White Truffle MB</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15545">Bakels Yeast Raised Donut Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=29100">Baktem Red V</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15513">Baktem Special V</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15676">Balec</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17152">Bavarian Supreme</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17092">Biscuit Crumb Base MB</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15509">Brittex 2000 V</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15572">Cake Margarine Medium</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15706">Canola Oil RBD</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15633">Chockex Supreme MB</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15634">Chockex White MB</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17760">Chocolate Lava Cake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17980">Country Oven Artisan Concentrate</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15560">Creme Shortening - Medium Grade</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17019">Eggless Vanilla Cake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15514">Eminex V</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15680">Fino Batter Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15568">Fino Meat Pie Seasoning</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15571">Fino Potato Pie Mash</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15626">Fondant White - Soft</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15637">Hadeja Flan Gel Neutral</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=16684">Hamburger Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15673">Hercules Baking Powder</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17150">Kramess Vanilla Slice Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=16683">Masterfat Supreme V</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15515">Merita V MB</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15575">Ovalett</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15552">Pastry Gems - (Medium Grade)</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15557">Pastry Gems (Hard Grade)</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17120">Pettina Apple and Blueberry Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15623">Pettina Cheesecake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17763">Pettina Chocolate Cake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15664">Pettina Chocolate Flavoured Paste</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15677">Pettina Choux Paste Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15593">Pettina Cream Stabiliser</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15624">Pettina Fond Suisse</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17073">Pettina Fruit and Nut Loaf Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15601">Pettina Kokomix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15641">Pettina Lamington Dip</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15683">Pettina Pavlova Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15642">Pettina Raspberry Dip</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15561">Pie Base Concentrate</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15563">Pie Bottom Fat V</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17787">Romero Vanilla Slice Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17898">Scandinavian Rye Bread Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15554">Shortpaste Margarine - Medium Grade</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17741">Super Glossy Natural</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=17016">Vegan Cake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15573">Vegetable Cake Margarine</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15558">Vegetable Pastry Nuggets - Hard Grade</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15553">Vegetable Pastry Nuggets - Medium Grade</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15512">Voltem</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?product-used%5B%5D=15577">Wispalett Special - MB</a>
+          </li>
+
+        
+      </ul>
+    </li>
+    
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Finished products</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1805" >Baguette</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5125" >Banana Cake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4894" >Banana Loaf</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4587" >Batters &amp; Potato</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1844" >Biscuit</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5077" >Biscuit Base</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5081" >Bread and Rolls</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4032" >Bread Rolls</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1825" >Brioche</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1840" >Brownie</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4246" >Buttacake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4255" >Butter and Golden Cherry Bars</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4989" >Butter Bars</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link sidr-class-menuparent" >Cake</a>
+
+                    <ul class="sidr-class-submenu">
+            <li class="sidr-class-item sidr-depth-3 sidr-level-header">
+              <a class="sidr-level-back">Back</a>
+              <a class="menu-btn">
+                <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+              </a>
+            </li>
+            <li class="sidr-class-item sidr-depth-3">
+              <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1835">Cake</a>
+            </li>
+
+                          <li class="sidr-class-item sidr-depth-3">
+                <a href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4578" class="sidr-class-link">Various Cake Varieties</a>
+              </li>
+                          <li class="sidr-class-item sidr-depth-3">
+                <a href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4580" class="sidr-class-link">Eclairs</a>
+              </li>
+                      </ul>
+                </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4278" >Caramel Slice</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5028" >Carrot Cake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1845" >Cheesecake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1849" >Chilled Dough</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4965" >Chocolate Cake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4370" >Chocolate Hedgehog Slice</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4964" >Chocolate Lava Cake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1841" >Choux</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5029" >Ciabatta</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5110" >Coconut Drops</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4845" >Coffee Cups</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1838" >Confectionery</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1820" >Cookies</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1812" >Cracker</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4325" >Cream</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5153" >Cream Cheese</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5150" >Cream or Fruit Buns</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1823" >Croissant</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1804" >Crusty Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1806" >Crusty Roll</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1821" >Crusty Rolls</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1837" >Cupcake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1839" >Custard</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5157" >Damper</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1824" >Danish</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1830" >Dessert</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5088" >Dip</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5147" >Donut</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5148" >Dough</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1826" >Doughnut</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5159" >Eggless</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4998" >Fermdor</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4167" >Filling</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1807" >Flat Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4863" >Flourless Cake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4219" >Focaccia</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5100" >Fruit Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4820" >Fruit Cake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4878" >Fruit Loaf</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1831" >Fruit Tart</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5073" >Ganache</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1846" >Gateaux</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5037" >Gingerbread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4803" >Glaze</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1852" >Gluten Free</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5086" >Hamburger and Hot Dog Rolls</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1828" >Hamburger Bun</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4778" >Honey Roll</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1816" >Hot Cross Bun</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1847" >Ice Cream</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4572" >Icings</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5035" >Loaf</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5152" >Macarons</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5109" >Macaroons</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link sidr-class-menuparent" >Meat Pie</a>
+
+                    <ul class="sidr-class-submenu">
+            <li class="sidr-class-item sidr-depth-3 sidr-level-header">
+              <a class="sidr-level-back">Back</a>
+              <a class="menu-btn">
+                <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+              </a>
+            </li>
+            <li class="sidr-class-item sidr-depth-3">
+              <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4176">Meat Pie</a>
+            </li>
+
+                          <li class="sidr-class-item sidr-depth-3">
+                <a href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5156" class="sidr-class-link">Vegetable Pie</a>
+              </li>
+                      </ul>
+                </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5041" >Melting Moments</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4810" >Meringue</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4149" >Mock Cream</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5055" >Mousse</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4304" >Mud Cake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1808" >Muffin</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1811" >Multiseed</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1815" >Ocassion Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1809" >Occasion Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1848" >Pancake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1818" >Panettone</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4121" >Pastry Gems</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4157" >Pie Base</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4161" >Pie Bottoms</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4220" >Pizza</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4195" >Potato Pie Mash</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5158" >Pretzel</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4824" >Pudding</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4186" >Quiche</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4962" >Red Velvet Cake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5038" >Rock Cake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1810" >Rye Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5007" >Sauce</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1832" >Sausage Roll</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1833" >Savoury Good</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5139" >Savoury Loaf</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1819" >Scone</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1829" >Scotch Roll</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4839" >Shortbread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4130" >Shortpaste Margarine</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5076" >Slice Base</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1842" >Sliced Line</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4351" >Slices</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4359" >Snack Slice</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5115" >Snoerzel</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1814" >Soft Roll</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1817" >Speciality Bun</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1834" >Sponge</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4887" >Sticky Date</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1850" >Stollen</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1851" >Sweet Food</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1827" >Sweet Good</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1836" >Swiss Roll</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5093" >Syrup</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5149" >Tart</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5151" >Tiger Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1813" >Tin Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4861" >Topping</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5154" >Topping - Glazes and Gels</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4682" >Toppings - Glazes and gles</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4779" >Torte</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1843" >Traybake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5114" >Turkish Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5155" >Vanilla Slice</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4089" >Various Bread Products</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=5177" >Vegan</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=4125" >Vegetable Pastry Nuggets</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?finished-product%5B%5D=1822" >Wholemeal</a>
+
+                  </li>
+            </ul>
+    </li>
+    
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Display conditions</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?display-condition%5B%5D=1801" >Ambient</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?display-condition%5B%5D=1802" >Chilled</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?display-condition%5B%5D=1803" >Frozen</a>
+
+                  </li>
+            </ul>
+    </li>
+    
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Occasion</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?occasion%5B%5D=2855" >Afternoon Tea</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?occasion%5B%5D=2856" >BBQ</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?occasion%5B%5D=2854" >Christmas</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?occasion%5B%5D=2857" >Easter</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?occasion%5B%5D=2859" >Halloween</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?occasion%5B%5D=2861" >Mother's Day</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?occasion%5B%5D=2860" >Summer</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/recipes/?occasion%5B%5D=2858" >Valentine's Day</a>
+
+                  </li>
+            </ul>
+    </li>
+      </ul>
+</div>
+
+<div id="news-nav" class="sidr right">
+  <ul class="sidr-class-menu sidr-class-menu-top">
+    <li class="sidr-class-item sidr-depth-1 sidr-level-header">
+      <span class="sidr-label">Filter News</span>
+      <a class="menu-btn">
+        <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+      </a>
+    </li>
+
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Categories</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/category/events/" >Events</a>
+
+                  </li>
+            </ul>
+    </li>
+    
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Archives</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+        	<li class="sidr-class-item sidr-depth-2 sidr-item-archive"><a href='https://www.bakels.com.au/2018/10/'>October 2018</a></li>
+      </ul>
+    </li>
+    
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Tags</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/tag/2974/" >2974</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/tag/2975/" >2975</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/tag/bread-concentrate/" >Bread Concentrate</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/tag/cake/" >Cake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/tag/caramel-ripple/" >Caramel Ripple</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/tag/low-aw-caramel/" >Low AW Caramel</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/tag/low-sugar-caramel/" >Low Sugar Caramel</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/tag/millionaires-caramel/" >Millionaires Caramel</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/tag/millionaires-caramel-extra/" >Millionaires Caramel Extra</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/tag/multimix-cake-base/" >Multimix Cake Base</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/tag/palm-free/" >Palm Free</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/tag/rtu-caramel-sauce/" >RTU Caramel Sauce</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/tag/rye/" >Rye</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/tag/salted-caramel/" >Salted Caramel</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/tag/slice/" >Slice</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/tag/sourdough/" >Sourdough</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/tag/students/" >Students</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/tag/training/" >Training</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/tag/traybake/" >Traybake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.bakels.com.au/tag/true-caramel/" >True Caramel</a>
+
+                  </li>
+            </ul>
+    </li>
+      </ul>
+</div>
+
+<div id="insight-nav" class="sidr right">
+  <ul class="sidr-class-menu sidr-class-menu-top">
+    <li class="sidr-class-item sidr-depth-1 sidr-level-header">
+      <span class="sidr-label">Filter Insights</span>
+      <a class="menu-btn">
+        <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+      </a>
+    </li>
+
+    
+    
+      </ul>
+</div>
+<!-- Modal -->
+<div class="modal fade" id="select-country" tabindex="-1" role="dialog" aria-labelledby="select-country" aria-hidden="true">
+  <div class="modal-dialog modal-lg" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3 class="modal-title">Bakels Worldwide</h3>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">
+            <img src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Close">
+          </span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <ul class="row list-group-trans"><li class="list-group-item list-group-item-trans col-6" id="list-africa"><h3>Africa</h3><ul class="row list-group-trans"><li class="list-group-item list-group-item-trans col-6"><a href="http://www.sbakels.co.za" target="_blank">South Africa</a></li></ul></li><li class="list-group-item list-group-item-trans col-6" id="list-antarctica"><h3>Antarctica</h3><ul class="row list-group-trans"></ul></li><li class="list-group-item list-group-item-trans col-6" id="list-asia"><h3>Asia</h3><ul class="row list-group-trans"><li class="list-group-item list-group-item-trans col-6"><a href="http://www.hkbakels.com.hk" target="_blank">Hong Kong</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakels.in" target="_blank">India</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://http://www.bakels.com.cn/" target="_blank">Mainland China</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.maybakels.com" target="_blank">Malaysia</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakelsph.com" target="_blank">Philippines</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakelsingapore.com.sg" target="_blank">Singapore</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakels.co.th" target="_blank">Thailand</a></li></ul></li><li class="list-group-item list-group-item-trans col-6" id="list-europe"><h3>Europe</h3><ul class="row list-group-trans"><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakbel.com" target="_blank">Belgium</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.finnbakels.fi" target="_blank">Finland</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakelsdeutschland.de" target="_blank">Germany</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakels.hu" target="_blank">Hungary</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.irishbakels.ie" target="_blank">Ireland</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakels-senior.nl" target="_blank">Netherlands</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakels.pl" target="_blank">Poland</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.nordbakels.se" target="_blank">Sweden</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakels.ch" target="_blank">Switzerland</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.britishbakels.co.uk" target="_blank">United Kingdom</a></li></ul></li><li class="list-group-item list-group-item-trans col-6" id="list-oceania"><h3>Oceania</h3><ul class="row list-group-trans"><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakels.com.au" target="_blank">Australia</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakelsfiji.com.fj" target="_blank">Fiji</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.nzbakels.co.nz" target="_blank">New Zealand</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.beobakels.co.nz" target="_blank">New Zealand - Edible Oils</a></li></ul></li><li class="list-group-item list-group-item-trans col-6" id="list-north-america"><h3>North America</h3><ul class="row list-group-trans"><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakelsusa.com" target="_blank">United States</a></li></ul></li><li class="list-group-item list-group-item-trans col-6" id="list-south-america"><h3>South America</h3><ul class="row list-group-trans"><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakels.com.br" target="_blank">Brazil</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakelschile.cl" target="_blank">Chile</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakels.com.ec" target="_blank">Ecuador</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakels.pe" target="_blank">Peru</a></li></ul></li></ul>      </div>
+      <div class="modal-footer" style="margin: 0 40px;">
+        <a href="https://www.bakels.com/" target="_blank" class="btn btn-orange btn-icon-right btn-fa-angle-right">Visit Bakels Group</a>
+      </div>
+    </div>
+  </div>
+</div>	        <script type="text/javascript">
+			var imdmsHomePageURL = "https://www.bakels.com.au/";
+		</script>
+<script type="text/javascript">
+	var viewallTranslation = 'View all';
+	var productsTranslation = 'Products';
+	var recipesTranslation = 'Recipes';
+	var allTranslation = 'All';
+	var noResult = 'No result for';
+	var moreButton = 'More';
+</script>
+		<div class="imdms-social-media d-none d-lg-block">
+			<ul>
+								<li>
+					<a href="https://www.facebook.com/AustralianBakels/" title="Facebook" target="_blank" class="fa fa-facebook"><span>Facebook</span></a>
+				</li>
+				
+				
+				
+								<li>
+					<a href="https://instagram.com/bakelsau" title="Instagram" target="_blank" class="fa fa-instagram"><span>Instagram</span></a>
+				</li>
+				
+								<li>
+					<a href="https://linkedin.com/company/australian-bakels-01" title="Linkedin" target="_blank" class="fa fa-linkedin"><span>Linkedin</span></a>
+				</li>
+				
+				
+				
+				
+								<li>
+										<a href="https://www.bakels.com.au/email-newsletter/" title="Newsletter" target="_blank" class="fa fa-envelope"><span>Newsletter</span></a>
+				</li>
+							</ul>
+		</div>
+    <script type="text/javascript" src="//cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js?ver=6.5.2" id="ccc-cookie-control-js"></script>
+<script type="text/javascript" src="https://www.bakels.com.au/wp-content/plugins/duracelltomi-google-tag-manager/dist/js/gtm4wp-form-move-tracker.js?ver=1.20.2" id="gtm4wp-form-move-tracker-js"></script>
+<script type="text/javascript" src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/js/vendor.min.js?ver=9.5.4" id="imdms-js-vendor-js"></script>
+<script type="text/javascript" src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/js/app.min.js?ver=9.5.4" id="imdms-js-js"></script>
+<script type="text/javascript" id="imdms-js-ajax-js-extra">
+/* <![CDATA[ */
+var imdms_ajax = {"ajaxnonce":"379154000d","query":{"page":"","recipes":"plant-based-burger-patty-using-bakels-plant-based-savoury-mix","post_type":"recipes","name":"plant-based-burger-patty-using-bakels-plant-based-savoury-mix"},"ajaxurl":"https:\/\/www.bakels.com.au\/wp-admin\/admin-ajax.php?wpml_lang=en"};
+/* ]]> */
+</script>
+<script type="text/javascript" async="async" src="https://www.bakels.com.au/wp-content/themes/bakels-local/assets/js/ajax-script.min.js?ver=9.5.4" id="imdms-js-ajax-js"></script>
+<script></script>            <script type="text/javascript">
+
+                var config = {
+                    apiKey: 'd80d368542e1554ea2b89ac15890cc3d4cbe2e72',
+                    product: 'PRO_MULTISITE',
+                    logConsent: false,
+                    notifyOnce: false,
+                    initialState: 'NOTIFY',
+                    position: 'RIGHT',
+                    theme: 'DARK',
+                    layout: 'POPUP',
+                    toggleType: 'slider',
+                    acceptBehaviour :  'recommended',
+                    closeOnGlobalChange : true,
+                    iabCMP: false,
+                                        closeStyle: 'button',
+                    consentCookieExpiry: 90,
+                    subDomains :  true,
+                    mode :  'gdpr',
+                    rejectButton: false,
+                    settingsStyle : 'link',
+                    encodeCookie : false,
+                    setInnerHTML: true,
+                    accessibility: {
+                        accessKey: 'C',
+                        highlightFocus: false,
+                        outline: false,
+                        overlay: true,
+                        disableSiteScrolling: false,                       
+                    },
+                                        text: {
+                        title: 'This site uses cookies',
+                        intro: 'Some of these cookies are essential, while others help us to improve your experience by providing insights into how the site is being used.',
+                        necessaryTitle: 'Necessary Cookies',
+                        necessaryDescription: 'Necessary cookies enable core functionality. The website cannot function properly without these cookies, and can only be disabled by changing your browser preferences.',
+                        thirdPartyTitle: 'Warning: Some cookies require your attention',
+                        thirdPartyDescription: 'Consent for the following cookies could not be automatically revoked. Please follow the link(s) below to opt out manually.',
+                        on: 'On',
+                        off: 'Off',
+                        accept: 'Accept Recommended Settings',
+                        settings: 'Cookie Preferences',
+                        acceptRecommended: 'Accept Recommended Settings',
+                        acceptSettings: 'Accept Recommended Settings',
+                        notifyTitle: 'Your choice regarding cookies on this site',
+                        notifyDescription: 'We use cookies to optimise site functionality and give you the best possible experience.',
+                        closeLabel: 'Close',
+                        cornerButton :  'Set cookie preferences.',
+                        landmark :  'Cookie preferences.',
+                        showVendors : 'Show vendors within this category',
+                        thirdPartyCookies : 'This vendor may set third party cookies.',
+                        readMore : 'Read more',
+                        accessibilityAlert: 'This site uses cookies to store information. Press accesskey C to learn more about your options.',
+                        rejectSettings: 'I Do Not Accept',
+                        reject: 'I Do Not Accept',
+                                            },
+                    
+                    branding: {
+                        fontColor: '#fff',
+                        fontFamily: '\&quot;Univers LT W01_59 Ult Cond\&quot;,Arial,serif',
+                        fontSizeTitle: '2em',
+                        fontSizeHeaders: '1.5em',
+                        fontSize: '0.94em',
+                        backgroundColor: '#003976',
+                        toggleText: '#fff',
+                        toggleColor: '#ea5f40',
+                        toggleBackground: '#111125',
+                        alertText: '#fff',
+                        alertBackground: '#003976',
+                        acceptText: '#ffffff',
+                        acceptBackground: '#ea5f40',
+                        rejectText: '#ffffff',
+                        rejectBackground: '#111125',
+                        closeText : '#111125',
+                        closeBackground : '#FFF',
+                        notifyFontColor : '#FFF',
+                        notifyBackgroundColor: '#003976',
+                                                buttonIcon: 'https://www.bakels.com.au/wp-content/uploads/sites/21/2022/02/icon-cookie-control.svg',
+                                                buttonIconWidth: '64px',
+                        buttonIconHeight: '64px',
+                        removeIcon: false,
+                        removeAbout: true                    },
+                                        
+                                                            
+                  
+                                                                                
+                                        necessaryCookies: [ 'wordpress_*','wordpress_logged_in_*','CookieControl','lang','tr','bakels_geo_funnel' ],
+                    
+                                        optionalCookies: [
+                                                                        {
+                            name: 'analytics',
+                            label: 'Analytical Cookies',
+                            description: 'Analytical cookies help us to improve our website by collecting and reporting information on its usage.',
+                                                        cookies: [ '_ga', '_gat', '_gid', 'Collect' ],
+                            onAccept: function () {
+                                dataLayer.push({
+    'civic_cookies_analytics': 'consent_given',
+    'event': 'analytics_consent_given',
+});                            },
+                            onRevoke: function () {
+                                dataLayer.push({
+    'civic_cookies_analytics': 'consent_revoked',
+});                            },
+                                                        recommendedState: 'on',
+                            lawfulBasis: 'consent',
+                        
+                            
+                        },
+                                                                                                {
+                            name: 'targeting-advertising',
+                            label: 'Targeting / Advertising',
+                            description: 'We use marketing cookies to help us improve the relevancy of advertising campaigns you receive.',
+                                                        cookies: [ 'Fr', 'i/jot', 'i/jot/syndication', 'impression.php/#' ],
+                            onAccept: function () {
+                                                            },
+                            onRevoke: function () {
+                                                            },
+                                                        recommendedState: 'on',
+                            lawfulBasis: 'consent',
+                        
+                            
+                        },
+                                                                    ],
+                                                            sameSiteCookie : true,
+                    sameSiteValue : 'Strict',
+                    notifyDismissButton: false
+                };
+                CookieControl.load(config);
+            </script>
+
+            </body>
+</html>


### PR DESCRIPTION
This attempts a couple of things, to address https://github.com/hhursev/recipe-scrapers/pull/1097#discussion_r1581145980

* Adds support for ingredient groups.
* Returns an empty group `purpose` field if there's only a single ingredient group for a recipe.